### PR TITLE
Add docstrings and tests

### DIFF
--- a/pwnv/utils/config.py
+++ b/pwnv/utils/config.py
@@ -1,3 +1,10 @@
+"""Utilities for loading and storing the ``pwnv`` configuration.
+
+The configuration is stored as JSON on disk.  This module resolves the
+location of that file, exposes helpers to read and write it and provides
+simple accessor helpers used across the code base.
+"""
+
 from functools import lru_cache
 from pathlib import Path
 
@@ -8,6 +15,7 @@ load_dotenv()
 
 
 def _resolve_config_path() -> Path:
+    """Return the path of the configuration file."""
     import os
 
     import typer
@@ -35,6 +43,7 @@ _lock = SoftFileLock(str(config_path) + ".lock")
 
 @lru_cache(maxsize=1)
 def load_config() -> dict:
+    """Load and return the JSON configuration as a dictionary."""
     import json
 
     if not config_path.exists():
@@ -44,10 +53,12 @@ def load_config() -> dict:
 
 
 def _invalidate_cache() -> None:
+    """Clear the cached configuration."""
     load_config.cache_clear()
 
 
 def save_config(cfg: dict) -> None:
+    """Write ``cfg`` to disk atomically and invalidate the cache."""
     import json
     import os
     from tempfile import NamedTemporaryFile
@@ -69,20 +80,24 @@ def save_config(cfg: dict) -> None:
 
 
 def get_config_path() -> Path:
+    """Return the resolved configuration path."""
     return config_path
 
 
 def get_ctfs_path() -> Path:
+    """Return the path on disk where CTFs are stored."""
     config = load_config()
     return Path(config["ctfs_path"])
 
 
 def get_config_value(key: str) -> any:
+    """Return a value from the configuration by ``key``."""
     config = load_config()
     return config.get(key)
 
 
 def set_config_value(key: str, value: any) -> None:
+    """Set a ``key`` in the configuration and persist it."""
     config = load_config()
     config[key] = value
     save_config(config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dev = [
   "mypy",
   "ruff",
   "pre-commit",
+  "pytest",
 ]
 
 [project.urls]
@@ -56,3 +57,7 @@ local_scheme = "no-local-version"
 [tool.setuptools.packages.find]
 where = ["."]
 exclude = ["plugin_examples*"]
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = ["tests"]

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -1,0 +1,36 @@
+import importlib
+
+from pwnv.models import CTF
+from pwnv.models.ctf import Status
+
+
+def _reload_modules():
+    import pwnv.utils.config as config
+    import pwnv.utils.crud as crud
+    importlib.reload(config)
+    importlib.reload(crud)
+    return config, crud
+
+
+def test_is_duplicate(tmp_path, monkeypatch):
+    monkeypatch.setenv('PWNV_CONFIG', str(tmp_path / 'cfg.json'))
+    config, crud = _reload_modules()
+
+    ctfs = [CTF(name='one', path=tmp_path/'one')]
+    assert crud.is_duplicate(name='one', model_list=ctfs)
+    assert crud.is_duplicate(path=tmp_path/'one', model_list=ctfs)
+    assert crud.is_duplicate(name='one', path=tmp_path/'other', model_list=ctfs)
+    assert not crud.is_duplicate(name='two', path=tmp_path/'two', model_list=ctfs)
+
+
+def test_update_ctf(tmp_path, monkeypatch):
+    monkeypatch.setenv('PWNV_CONFIG', str(tmp_path / 'cfg.json'))
+    config, crud = _reload_modules()
+
+    ctf = CTF(name='ctf', path=tmp_path/'ctf')
+    crud.add_ctf(ctf)
+    ctf.running = Status.stopped
+    crud.update_ctf(ctf)
+
+    reloaded = crud.get_ctfs()[0]
+    assert reloaded.running == Status.stopped

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,35 @@
+import importlib
+import shutil
+from pathlib import Path
+
+from pwnv.models.challenge import Category
+
+
+def _reload_modules():
+    config = importlib.import_module("pwnv.utils.config")
+    plugin = importlib.import_module("pwnv.utils.plugin")
+    manager_mod = importlib.import_module("pwnv.core.plugin_manager")
+    importlib.reload(config)
+    importlib.reload(plugin)
+    importlib.reload(manager_mod)
+    return plugin, manager_mod
+
+
+def test_plugin_selection(tmp_path, monkeypatch):
+    monkeypatch.setenv('PWNV_CONFIG', str(tmp_path / 'cfg.json'))
+    plugin, manager = _reload_modules()
+
+    root = Path(__file__).resolve().parents[1]
+    plugin_src = root / 'plugin_examples' / 'plugins' / 'pwn_example.py'
+    dest_dir = plugin.get_plugins_directory()
+    shutil.copy(plugin_src, dest_dir / plugin_src.name)
+
+    manager.plugin_manager.discover_and_load_plugins()
+
+    plugin.set_selected_plugin_for_category(Category.pwn, 'pwn_example')
+    loaded = plugin.get_selected_plugin_for_category(Category.pwn)
+    assert loaded is not None
+    assert loaded.__class__.__name__ == 'PwnPlugin'
+
+    plugin.remove_selected_plugin_for_category(Category.pwn)
+    assert plugin.get_selected_plugin_for_category(Category.pwn) is None


### PR DESCRIPTION
## Summary
- document config and remote utility modules
- add pytest configuration and dependency
- implement basic unit tests
- fix reloading plugin manager module in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e9b648fe083318459fb2f5dfd26eb