### PR TITLE
Fix NameError in remote_solve

### DIFF
--- a/pwnv/utils/remote.py
+++ b/pwnv/utils/remote.py
@@ -219,5 +219,7 @@ async def remote_solve(ctf: CTF, challenge: Challenge, flag: str) -> bool:
             error(f"Flag [cyan]{flag}[/] incorrect")
             return False
     except Exception:
+        from pwnv.utils.ui import error
+
         error(f"Failed to submit flag '{flag}'.")
         return False


### PR DESCRIPTION
## Summary
- import `error` when handling exceptions in `remote_solve`

## Testing
- `python` stubbed run of `remote_solve`

------
https://chatgpt.com/codex/tasks/task_e_686e9b496cf08331bf72a14ba77bc4ed