### PR TITLE
fix: render the docs icons, drop PWNV_DEBUG, restore the original style

### DIFF
--- a/docs/guide/remote.md
+++ b/docs/guide/remote.md
@@ -100,19 +100,6 @@ pwnv ctf sync --ctf ExampleCTF --platform rctf
 Detection failing for a public event is worth reporting upstream — it is a small
 patch, and the platform support itself is usually already there.
 
-## When something fails and the message is too short
-
-Remote failures print a sentence, because the traceback under it is rarely what
-you want mid-event. Set `PWNV_DEBUG=1` to get both:
-
-```bash
-PWNV_DEBUG=1 pwnv ctf sync --ctf DemoCTF
-```
-
-The traceback goes to stderr with the rest of the diagnostics, so `--json`
-output on stdout stays parseable. It covers connecting, authenticating, fetching
-challenges, downloading attachments and submitting flags.
-
 ## Submitting
 
 ```bash

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -13,7 +13,7 @@ same thing in the terminal.
 
 ### `pwnv doctor`
 
-Check configuration, paths, tools, and workspace consistency.
+Checks configuration, paths, tools, and workspace consistency.
 
 ```
 pwnv doctor [OPTIONS]
@@ -49,9 +49,7 @@ pwnv reset [OPTIONS]
 
 ### `pwnv shell-init`
 
-Print the shell functions that add `pwncd` to your session.
-
-Add `eval "$(pwnv shell-init)"` to your shell's rc file, or `pwnv shell-init | source` for fish.
+Prints the shell functions that add `pwncd` to your session. Add `eval "$(pwnv shell-init)"` to your shell's rc file, or `pwnv shell-init | source` for fish.
 
 ```
 pwnv shell-init [OPTIONS]
@@ -80,7 +78,7 @@ pwnv solve [OPTIONS]
 
 ### `pwnv status`
 
-Show challenge and point progress for the workspace.
+Shows challenge and point progress for the workspace.
 
 ```
 pwnv status [OPTIONS]
@@ -211,7 +209,7 @@ pwnv challenge path [OPTIONS] [CHALLENGE_NAME]
 
 ### `pwnv challenge env add`
 
-Install packages into a challenge-local virtual environment.
+Installs packages into a challenge-local virtual environment.
 
 ```
 pwnv challenge env add [OPTIONS] PACKAGES...
@@ -228,7 +226,7 @@ pwnv challenge env add [OPTIONS] PACKAGES...
 
 ### `pwnv challenge env run`
 
-Run a command with the challenge environment on PATH.
+Runs a command with the challenge environment on PATH.
 
 ```
 pwnv challenge env run [OPTIONS]
@@ -241,7 +239,7 @@ pwnv challenge env run [OPTIONS]
 
 ### `pwnv challenge note add`
 
-Append a timestamped entry to a challenge's NOTES.md file.
+Appends a timestamped entry to a challenge's NOTES.md file.
 
 ```
 pwnv challenge note add [OPTIONS] TEXT
@@ -259,7 +257,7 @@ pwnv challenge note add [OPTIONS] TEXT
 
 ### `pwnv challenge note show`
 
-Render a challenge's NOTES.md file.
+Renders a challenge's NOTES.md file.
 
 ```
 pwnv challenge note show [OPTIONS]
@@ -405,7 +403,7 @@ pwnv plugin select [OPTIONS]
 
 ### `pwnv workspace backup`
 
-Create a full archive, including challenge files and credentials.
+Creates a full archive, including challenge files and credentials.
 
 ```
 pwnv workspace backup [OPTIONS] [DESTINATION]
@@ -421,7 +419,7 @@ pwnv workspace backup [OPTIONS] [DESTINATION]
 
 ### `pwnv workspace restore`
 
-Restore a full backup archive: challenge files, notes, and credentials.
+Restores a full backup archive: challenge files, notes, and credentials.
 
 ```
 pwnv workspace restore [OPTIONS] SOURCE
@@ -438,7 +436,7 @@ pwnv workspace restore [OPTIONS] SOURCE
 
 ### `pwnv workspace export`
 
-Export portable metadata without challenge files or credentials.
+Exports portable metadata without challenge files or credentials.
 
 ```
 pwnv workspace export [OPTIONS] [DESTINATION]
@@ -450,7 +448,7 @@ pwnv workspace export [OPTIONS] [DESTINATION]
 
 ### `pwnv workspace import`
 
-Merge a portable export into the current workspace.
+Merges a portable export into the current workspace.
 
 ```
 pwnv workspace import [OPTIONS] SOURCE

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,9 @@ nav:
 markdown_extensions:
   - admonition
   - attr_list
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - def_list
   - md_in_html
   - tables

--- a/pwnv/__init__.py
+++ b/pwnv/__init__.py
@@ -1,26 +1,9 @@
-"""pwnv - a workspace manager for CTFs.
-
-Both public names are resolved on demand. A solve script asks for
-``from pwnv import challenge``, and assembling the Typer app to answer that
-would import every command module - typer, rich and InquirerPy - for an object
-that needs none of them.
-
-``challenge`` is resolved when it is imported, from the working directory, and
-is an ordinary :class:`ctfbridge.models.challenge.Challenge` afterwards. Call
-:func:`pwnv.api.current` again if the directory changes under you - it is also
-the form to reach for when a script wants to handle the "not in a challenge"
-case itself, since importing the name raises
-:class:`pwnv.api.NoChallengeError` on the import line.
-"""
-
 from typing import TYPE_CHECKING, Any, List
 
 if TYPE_CHECKING:
     import typer
 
-# `challenge` is deliberately absent: it is not a value but a lookup, and a
-# `from pwnv import *` outside a challenge directory would raise NoChallengeError
-# on a name the caller never asked for. `__dir__` still advertises it.
+# `challenge` is left out of __all__ so star-imports cannot raise NoChallengeError.
 __all__ = ["app", "main"]
 
 _app: "typer.Typer | None" = None
@@ -79,5 +62,4 @@ def __dir__() -> List[str]:
 
 
 def main() -> None:
-    """Entry point for the ``pwnv`` console script."""
     _get_app()()

--- a/pwnv/api.py
+++ b/pwnv/api.py
@@ -1,21 +1,7 @@
-"""The challenge you are standing in, as the object ctfbridge already defines.
+"""Programmatic access to the current challenge.
 
-``pwnv challenge path`` answers "which challenge is this?" for the shell. This
-answers it for Python, so a solve script reads ``challenge.service.host``
-instead of a host that was baked into the file at scaffold time.
-
-The distinction matters during an event.
-:func:`pwnv.utils.template.render_template` substitutes ``{{service.host}}``
-once, when the file is written, and leaves the token untouched when it cannot
-resolve - so a challenge scaffolded before the first sync ends up with the
-literal in it, and a service that moves later strands every script already on
-disk. Reading it here binds the value at run time instead.
-
-What comes back is a :class:`ctfbridge.models.challenge.Challenge`, rebuilt from
-the workspace: the same object the sync fetched, with the same fields, helpers
-and serialisers. Two fields are added, because they are local facts the platform
-never sends - ``path``, since a script started from elsewhere still has to find
-its own files, and ``flag``, recorded by ``pwnv solve``.
+:func:`current` rebuilds the :class:`ctfbridge.models.challenge.Challenge` the
+sync stored for the working directory, with ``path`` and ``flag`` added.
 """
 
 from __future__ import annotations
@@ -33,22 +19,6 @@ class NoChallengeError(RuntimeError):
 
 
 def _mappings(value: object) -> list[Any]:
-    """
-    The mappings out of a stored list, whatever else ended up in it.
-
-    They are mappings, but the annotation says ``Any``: pydantic builds an
-    ``Attachment`` or a ``Service`` out of each one, and a checker reading the
-    field's declared type would rather see the model than the dict it came from.
-
-    ``extras`` is whatever the sync wrote, and a plugin or a hand-edited config
-    can leave a string or a null in there. Validating what is left is the
-    platform's business; this only makes sure a stray entry raises nothing when
-    the object is built.
-
-    A copy of the helper in :mod:`pwnv.utils.serialize` rather than an import of
-    it: reaching into ``pwnv.utils`` would pull the whole CLI into a solve
-    script, which is the one thing this module exists to avoid.
-    """
     if not isinstance(value, list):
         return []
     return [item for item in value if isinstance(item, dict)]
@@ -62,19 +32,15 @@ class LocalChallenge(Challenge):
 
 
 def current(path: Path | None = None) -> LocalChallenge:
-    """
-    Return the challenge that owns ``path``, or the working directory.
+    """Return the challenge that owns ``path``, or the working directory.
 
-    :raises NoChallengeError: when the directory belongs to no challenge.
+    Raises :class:`NoChallengeError` when the directory belongs to no challenge.
     """
     from pwnv.models.challenge import Solved
     from pwnv.utils.config import invalidate_cache
     from pwnv.utils.crud import get_current_challenge
 
     invalidate_cache()
-    # Resolved the same way the config is: a challenge is matched by comparing
-    # paths, and "~/ctfs/x", "./x" and a symlinked path are all the same
-    # directory to a caller but three different strings to `is_relative_to`.
     where = (Path(path) if path is not None else Path.cwd()).expanduser().resolve()
     record = get_current_challenge(where)
     if record is None:

--- a/pwnv/cli/challenge.py
+++ b/pwnv/cli/challenge.py
@@ -188,8 +188,6 @@ def info_(
         raise typer.Exit(code=1)
 
     if json_output:
-        # A picker cannot answer to a pipe, so this reports the scope it was
-        # given rather than asking which challenge was meant.
         if named:
             selection = named
         elif not all and not selected_ctf and (here := get_current_challenge()):
@@ -299,9 +297,6 @@ def search(
     challenges = challenges_for_ctf(selected_ctf) if selected_ctf else get_challenges()
     filters = (category, tag, min_points, max_points, has_service, solved)
     if not query and not any(value is not None and value != [] for value in filters):
-        # A bare `search --ctf X` used to return nothing, because the underlying
-        # helper treats "no query and no filter" as an empty result. Naming a
-        # scope is itself a request to see it.
         matches = list(challenges)
     else:
         matches = search_challenges(
@@ -315,7 +310,6 @@ def search(
             solved=solved,
         )
     if json_output:
-        # An empty result is a legitimate answer to a query, not a warning.
         emit_json({"challenges": challenges_payload(matches)})
         return
 
@@ -422,8 +416,6 @@ def scaffold(
     try:
         chosen_plugin.logic(challenge)
     except Exception as exc:
-        # A plugin run outside its own category can hit assumptions that do not
-        # hold, e.g. a pwn plugin looking for a binary in a web challenge.
         warn(f"Plugin logic failed for {challenge.name}: {exc}")
         raise typer.Exit(code=1) from exc
 

--- a/pwnv/cli/challenge_env.py
+++ b/pwnv/cli/challenge_env.py
@@ -1,5 +1,3 @@
-"""Per-challenge Python environments."""
-
 from pathlib import Path
 
 import typer
@@ -35,7 +33,7 @@ def add(
     challenge_name: str | None = typer.Option(None, "--challenge"),
     ctf: str | None = typer.Option(None, "--ctf"),
 ) -> None:
-    """Install packages into a challenge-local virtual environment."""
+    """Installs packages into a challenge-local virtual environment."""
     import subprocess
 
     from pwnv.utils import error, resolve_challenge, success
@@ -63,7 +61,7 @@ def run(
     challenge_name: str | None = typer.Option(None, "--challenge"),
     ctf: str | None = typer.Option(None, "--ctf"),
 ) -> None:
-    """Run a command with the challenge environment on PATH."""
+    """Runs a command with the challenge environment on PATH."""
     import os
     import subprocess
 

--- a/pwnv/cli/ctf.py
+++ b/pwnv/cli/ctf.py
@@ -19,7 +19,6 @@ PLATFORM = typer.Option(
 
 
 def _checked_platform(platform: str | None) -> str | None:
-    """Reject a platform name ctfbridge does not know, listing the ones it does."""
     from pwnv.utils import error
     from pwnv.utils.remote import known_platforms
 
@@ -109,7 +108,6 @@ def add(
             ),
             credentials if has_credentials else None,
         ):
-            # add_remote_ctf has already said what went wrong.
             raise typer.Exit(code=1)
     else:
         add_ctf(CTF(name=name, path=path))
@@ -176,7 +174,6 @@ def info_(
         raise typer.Exit(code=1)
 
     if json_output:
-        # Without a name to go on, report every CTF rather than prompt.
         emit_json({"ctfs": ctfs_payload([chosen_ctf] if chosen_ctf else get_ctfs())})
         return
 
@@ -324,8 +321,6 @@ def sync(
         warn("Selected CTF has no remote URL.")
         return
 
-    # Pinning it here is how a CTF added before the detection went wrong gets
-    # fixed: the choice is stored, so later syncs and flag submissions use it.
     platform = _checked_platform(platform)
     if platform and platform != chosen_ctf.platform:
         chosen_ctf.platform = platform
@@ -349,7 +344,6 @@ _MAX_WATCH_INTERVAL = 15 * 60
 
 
 def _watch(ctf: CTF, *, interval: int, refresh_attachments: bool) -> None:
-    """Poll ``ctf`` until it stops running or the user interrupts."""
     import time
 
     from pwnv.utils import (

--- a/pwnv/cli/doctor.py
+++ b/pwnv/cli/doctor.py
@@ -1,5 +1,3 @@
-"""Workspace health checks."""
-
 import typer
 
 from pwnv.utils import config_exists
@@ -10,7 +8,7 @@ app = typer.Typer(no_args_is_help=True)
 @app.command()
 @config_exists()
 def doctor() -> None:
-    """Check configuration, paths, tools, and workspace consistency."""
+    """Checks configuration, paths, tools, and workspace consistency."""
     import shutil
 
     from pydantic import ValidationError

--- a/pwnv/cli/init.py
+++ b/pwnv/cli/init.py
@@ -21,7 +21,6 @@ app = typer.Typer(no_args_is_help=True)
 
 
 def _report(result: CompletedProcess[str]) -> None:
-    """Surface the output of a failed uv invocation."""
     from pwnv.utils import warn
 
     output = (result.stderr or result.stdout or "").strip()

--- a/pwnv/cli/note.py
+++ b/pwnv/cli/note.py
@@ -1,10 +1,9 @@
-"""Markdown challenge notes."""
-
-from datetime import datetime
-
 import typer
 
-from pwnv.utils import challenges_exists, config_exists
+from pwnv.utils import (
+    challenges_exists,
+    config_exists,
+)
 
 app = typer.Typer(no_args_is_help=True, help="Manage challenge notes.")
 
@@ -18,7 +17,9 @@ def add(
     challenge_name: str | None = typer.Option(None, "--challenge"),
     ctf: str | None = typer.Option(None, "--ctf"),
 ) -> None:
-    """Append a timestamped entry to a challenge's NOTES.md file."""
+    """Appends a timestamped entry to a challenge's NOTES.md file."""
+    from datetime import datetime
+
     from pwnv.utils import resolve_challenge, success
 
     challenge = resolve_challenge(challenge_name=challenge_name, ctf_name=ctf)
@@ -38,7 +39,7 @@ def show(
     challenge_name: str | None = typer.Option(None, "--challenge"),
     ctf: str | None = typer.Option(None, "--ctf"),
 ) -> None:
-    """Render a challenge's NOTES.md file."""
+    """Renders a challenge's NOTES.md file."""
     from rich.console import Console
     from rich.markdown import Markdown
 

--- a/pwnv/cli/options.py
+++ b/pwnv/cli/options.py
@@ -1,5 +1,3 @@
-"""Options shared by more than one command."""
-
 import typer
 
 JSON = typer.Option(
@@ -7,9 +5,3 @@ JSON = typer.Option(
     "--json",
     help="Print the result as JSON on stdout instead of a rendered view",
 )
-"""Ask a read command for data rather than a display.
-
-Declared once so every command spells the flag the same way, and so the
-contract stays visible: JSON goes to stdout, nothing else does, and a command
-in this mode never opens a picker - there is no one to answer it.
-"""

--- a/pwnv/cli/plugin.py
+++ b/pwnv/cli/plugin.py
@@ -159,8 +159,6 @@ def info_(json_output: bool = JSON) -> None:
     plugins = plugin_manager.get_all_plugins()
 
     if json_output:
-        # Every plugin at once: the rendered view exists to page through them
-        # one at a time, which a caller reading JSON does not need.
         emit_json({"plugins": plugins_payload(plugins)})
         return
 

--- a/pwnv/cli/shell.py
+++ b/pwnv/cli/shell.py
@@ -1,13 +1,9 @@
-"""Shell integration for pwnv."""
-
 import typer
 
 app = typer.Typer(no_args_is_help=True)
 
 _POSIX_INIT = """\
 pwncd() {
-    # `cd` has to happen in this shell, so pwnv prints the directory and the
-    # function does the moving. The picker draws on the terminal, not stdout.
     local target
     target="$(command pwnv challenge path "$@")" || return $?
     [ -n "$target" ] || return 1
@@ -40,9 +36,8 @@ def shell_init(
     ),
 ) -> None:
     """
-    Print the shell functions that add `pwncd` to your session.
-
-    Add `eval "$(pwnv shell-init)"` to your shell's rc file, or
+    Prints the shell functions that add `pwncd` to your session. Add
+    `eval "$(pwnv shell-init)"` to your shell's rc file, or
     `pwnv shell-init | source` for fish.
     """
     import os

--- a/pwnv/cli/solve.py
+++ b/pwnv/cli/solve.py
@@ -32,6 +32,9 @@ def solve(
     import asyncio
     from datetime import datetime
 
+    from rich.console import Console
+    from rich.table import Table
+
     from pwnv.models.challenge import Solved
     from pwnv.utils import (
         add_tags,
@@ -51,9 +54,6 @@ def solve(
         raise typer.Exit(code=1)
 
     if history:
-        from rich.console import Console
-        from rich.table import Table
-
         challenge = resolve_challenge(
             challenge_name=challenge_name,
             ctf_name=ctf,

--- a/pwnv/cli/status.py
+++ b/pwnv/cli/status.py
@@ -1,5 +1,3 @@
-"""Workspace dashboard."""
-
 import typer
 
 from pwnv.cli.options import JSON
@@ -9,7 +7,6 @@ app = typer.Typer(no_args_is_help=True)
 
 
 def _last_solve(challenge) -> str | None:
-    """Return the timestamp of the accepted submission, if one was recorded."""
     extras = challenge.extras if isinstance(challenge.extras, dict) else {}
     attempts = [
         attempt
@@ -20,7 +17,6 @@ def _last_solve(challenge) -> str | None:
 
 
 def _ctf_row(ctf, challenges) -> dict:
-    """One dashboard row, from the challenges the caller already grouped."""
     from pwnv.models.challenge import Solved
 
     solved = [ch for ch in challenges if ch.solved == Solved.solved]
@@ -37,7 +33,6 @@ def _ctf_row(ctf, challenges) -> dict:
 
 
 def _category_rows(challenges) -> list[dict]:
-    """Break one CTF down by category, which is how you pick what to work on."""
     from pwnv.models.challenge import Solved
 
     rows: dict[str, dict] = {}
@@ -54,7 +49,6 @@ def _category_rows(challenges) -> list[dict]:
 
 
 def _todo(challenges, limit: int) -> list[dict]:
-    """Cheapest unsolved challenges first: the usual next thing to look at."""
     from pwnv.models.challenge import Solved
     from pwnv.utils import format_service
 
@@ -108,7 +102,7 @@ def status(
     ),
     json_output: bool = JSON,
 ) -> None:
-    """Show challenge and point progress for the workspace."""
+    """Shows challenge and point progress for the workspace."""
     from typing import Any, cast
 
     from rich.console import Console
@@ -133,9 +127,6 @@ def status(
             raise typer.Exit(code=1)
         ctfs = [selected]
 
-    # Grouped once rather than asked for per CTF: every `challenges_for_ctf`
-    # call rebuilds the whole challenge list from the config, so the dashboard
-    # used to re-read the workspace once for each row it printed.
     grouped: dict[Any, list] = {}
     for item in get_challenges():
         grouped.setdefault(item.ctf_id, []).append(item)

--- a/pwnv/cli/workspace.py
+++ b/pwnv/cli/workspace.py
@@ -1,4 +1,3 @@
-import tarfile
 from pathlib import Path
 
 import typer
@@ -9,7 +8,6 @@ app = typer.Typer(no_args_is_help=True, help="Back up and transfer workspaces.")
 
 
 def _confirm_replace(replace: bool, force: bool) -> None:
-    """Ask before discarding metadata, unless there is none or --force was given."""
     from pwnv.utils import get_challenges, get_ctfs, prompt_confirm
 
     if not replace or force or not (get_ctfs() or get_challenges()):
@@ -21,7 +19,6 @@ def _confirm_replace(replace: bool, force: bool) -> None:
 
 
 def _report_merge(summary: dict[str, int], *, replace: bool) -> None:
-    """Say what the merge did with the records it was handed."""
     from pwnv.utils import info
 
     if replace:
@@ -44,7 +41,7 @@ def backup(
     destination: Path = typer.Argument(Path("pwnv-backup")),
     force: bool = typer.Option(False, "--force", "-f"),
 ) -> None:
-    """Create a full archive, including challenge files and credentials."""
+    """Creates a full archive, including challenge files and credentials."""
     from pwnv.utils import backup_workspace, error, success
 
     target = (
@@ -77,22 +74,21 @@ def restore(
         help="Discard the current metadata instead of merging into it",
     ),
 ) -> None:
-    """Restore a full backup archive: challenge files, notes, and credentials."""
+    """Restores a full backup archive: challenge files, notes, and credentials."""
+    import tarfile
+
     from pwnv.utils import error, info, restore_workspace, success
 
     _confirm_replace(replace, force)
 
     try:
         summary = restore_workspace(source, replace=replace, force=force)
-    except (FileNotFoundError, ValueError) as exc:
-        error(str(exc))
-        raise typer.Exit(code=1) from exc
-    # A file that is not an archive at all, or one whose members refuse to
-    # extract, raises a TarError. It is not a ValueError, so it used to reach
-    # the user as a traceback.
-    except tarfile.TarError as exc:
-        error(f"{source} could not be read as a backup archive: {exc}")
-        raise typer.Exit(code=1) from exc
+    except (FileNotFoundError, ValueError) as e:
+        error(str(e))
+        raise typer.Exit(code=1) from e
+    except tarfile.TarError as e:
+        error(f"{source} could not be read as a backup archive: {e}")
+        raise typer.Exit(code=1) from e
 
     success(f"Workspace restored from {source}")
     info(f"Copied {summary['files_restored']} file(s) into the CTF folder.")
@@ -102,7 +98,7 @@ def restore(
 @app.command(name="export")
 @config_exists()
 def export_(destination: Path = typer.Argument(Path("pwnv-export.json"))) -> None:
-    """Export portable metadata without challenge files or credentials."""
+    """Exports portable metadata without challenge files or credentials."""
     from pwnv.utils import export_workspace, success
 
     success(f"Workspace metadata exported to {export_workspace(destination)}")
@@ -121,21 +117,19 @@ def import_(
         help="Discard the current metadata instead of merging into it",
     ),
 ) -> None:
-    """Merge a portable export into the current workspace."""
+    """Merges a portable export into the current workspace."""
     from pwnv.utils import error, import_workspace, success
 
     _confirm_replace(replace, force)
 
     try:
         summary = import_workspace(source, replace=replace)
-    except FileNotFoundError as exc:
+    except FileNotFoundError as e:
         error(f"No export at {source}.")
-        raise typer.Exit(code=1) from exc
-    # Malformed JSON, or JSON that is not a workspace: both arrive as a
-    # ValueError, and neither is worth a traceback.
-    except ValueError as exc:
-        error(f"{source} is not a pwnv export: {exc}")
-        raise typer.Exit(code=1) from exc
+        raise typer.Exit(code=1) from e
+    except ValueError as e:
+        error(f"{source} is not a pwnv export: {e}")
+        raise typer.Exit(code=1) from e
 
     success(f"Workspace metadata imported from {source}")
     _report_merge(summary, replace=replace)

--- a/pwnv/constants.py
+++ b/pwnv/constants.py
@@ -8,10 +8,9 @@ DEFAULT_PWNVENV_FOLDER_NAME = ".pwnvenv"
 DEFAULT_PLUGINS_FOLDER_NAME = "plugins"
 DEFAULT_TEMPLATES_FOLDER_NAME = "templates"
 DEFAULT_SELECTION_FILE_NAME = "selection.json"
-# Plugins and templates shipped inside the package, copied in by `pwnv init`
 DEFAULT_EXAMPLES_FOLDER_NAME = "examples"
 
-# Default interpreter for the shared CTF environment
+# Default python version
 DEFAULT_PYTHON_VERSION = "3.13"
 
 # Default packages

--- a/pwnv/constants.py
+++ b/pwnv/constants.py
@@ -1,6 +1,5 @@
 # Environment variables
 PWNV_CONFIG_ENV = "PWNV_CONFIG"
-PWNV_DEBUG_ENV = "PWNV_DEBUG"
 
 # Default paths
 DEFAULT_CONFIG_BASENAME = "pwnv_config.json"

--- a/pwnv/core/plugin_manager.py
+++ b/pwnv/core/plugin_manager.py
@@ -17,7 +17,6 @@ _PLUGIN_MODULE_PREFIX = "pwnv_plugins"
 
 
 def plugin_name(plugin) -> str:
-    """Return the plugin's user-facing name (its file stem)."""
     return plugin.__module__.rpartition(".")[2]
 
 

--- a/pwnv/models/ctf.py
+++ b/pwnv/models/ctf.py
@@ -18,6 +18,4 @@ class CTF(BaseModel):
     path: Path
     running: Status = Status.running
     url: str | None = None
-    # The platform ctfbridge should talk to, when its own detection got it
-    # wrong. ``None`` means "detect", which is right for almost every event.
     platform: str | None = None

--- a/pwnv/plugins/plugin.py
+++ b/pwnv/plugins/plugin.py
@@ -11,8 +11,6 @@ from pwnv.models.challenge import Category
 
 @dataclass
 class TemplateWriteReport:
-    """What a run of ``create_template`` actually did on disk."""
-
     written: List[Path] = field(default_factory=list)
     skipped: List[Path] = field(default_factory=list)
 
@@ -31,13 +29,6 @@ _policy = _WritePolicy()
 def template_write_policy(
     *, force: bool = False, suffix: str = ""
 ) -> Generator[TemplateWriteReport]:
-    """
-    Control how templates are written for the duration of the block.
-
-    The policy lives here instead of in ``create_template``'s signature so it
-    also applies to plugins that override ``create_template``: every plugin
-    ultimately writes through :meth:`ChallengePlugin._write_template`.
-    """
     global _policy
 
     previous = _policy
@@ -50,7 +41,6 @@ def template_write_policy(
 
 
 def _apply_suffix(filename: str, suffix: str) -> str:
-    """Insert ``suffix`` before the extension, so ``solve.py`` -> ``solve_pwn.py``."""
     if not suffix:
         return filename
     stem, dot, extension = filename.rpartition(".")

--- a/pwnv/utils/__init__.py
+++ b/pwnv/utils/__init__.py
@@ -69,8 +69,6 @@ from pwnv.utils.serialize import (
 )
 from pwnv.utils.ui import (
     command,
-    debug_enabled,
-    debug_traceback,
     error,
     format_service,
     info,
@@ -168,8 +166,6 @@ __all__ = [
     "warn",
     "info",
     "command",
-    "debug_enabled",
-    "debug_traceback",
     "show_plugin",
     # plugin
     "get_bundled_examples_directory",

--- a/pwnv/utils/__init__.py
+++ b/pwnv/utils/__init__.py
@@ -97,6 +97,7 @@ from pwnv.utils.workspace import (
 )
 
 __all__ = [
+    # serialize
     "challenge_payload",
     "challenges_payload",
     "ctf_payload",
@@ -146,6 +147,7 @@ __all__ = [
     "remote_solve",
     "sanitize",
     "sync_remote_ctf",
+    # selection
     "resolve_challenge",
     # ui
     "prompt_confirm",

--- a/pwnv/utils/config.py
+++ b/pwnv/utils/config.py
@@ -5,7 +5,6 @@ location of that file, exposes helpers to read and write it and provides
 simple accessor helpers used across the code base.
 """
 
-import os
 from collections.abc import Generator
 from contextlib import contextmanager
 from functools import lru_cache
@@ -22,6 +21,8 @@ _EMPTY_CONFIG: dict = {"ctfs": [], "challenges": [], "challenge_tags": []}
 
 def _resolve_config_path() -> Path:
     """Return the path of the configuration file."""
+    import os
+
     from pwnv.constants import DEFAULT_CONFIG_BASENAME, PWNV_CONFIG_ENV
 
     if override := os.getenv(PWNV_CONFIG_ENV):
@@ -32,9 +33,7 @@ def _resolve_config_path() -> Path:
         if candidate.is_file():
             return candidate
 
-    # click rather than typer, which re-exports this same function: this is the
-    # branch a default install takes, and `from pwnv import challenge` reaches
-    # it, so a solve script would import the whole CLI to find its config.
+    # click, not typer, so a solve script does not import the whole CLI.
     from click import get_app_dir
 
     return Path(get_app_dir("pwnv")) / DEFAULT_CONFIG_BASENAME
@@ -74,18 +73,12 @@ def load_config() -> dict:
 
 
 def invalidate_cache() -> None:
-    """
-    Clear the cached configuration.
-
-    Every write goes through here, so a long-lived process - a solve script
-    calling :func:`pwnv.api.current`, or the shell - sees a change another
-    ``pwnv`` process made rather than the config as it was at import time.
-    """
+    """Clear the cached configuration."""
     load_config.cache_clear()
 
 
 def _write_config_file(cfg: dict) -> None:
-    """Serialise ``cfg`` to disk via a temp file and an atomic rename."""
+    """Write ``cfg`` to disk via a temp file and an atomic rename."""
     import json
     import os
     from tempfile import NamedTemporaryFile
@@ -112,14 +105,7 @@ def save_config(cfg: dict) -> None:
 
 @contextmanager
 def config_transaction() -> Generator[dict]:
-    """
-    Yield the configuration for mutation, holding the lock for the whole cycle.
-
-    Reading and writing under a single lock keeps concurrent ``pwnv`` processes
-    from clobbering each other: without it two commands can both read the same
-    config, each apply their own change, and the second write silently discards
-    the first (a lost solve or a lost synced challenge).
-    """
+    """Yield the configuration for mutation, holding the lock for the whole cycle."""
     with _lock:
         cfg = _read_config_file()
         yield cfg

--- a/pwnv/utils/crud.py
+++ b/pwnv/utils/crud.py
@@ -91,7 +91,6 @@ def search_challenges(
     has_service: bool | None = None,
     solved: bool | None = None,
 ) -> List[Challenge]:
-    """Return challenges whose searchable metadata contains ``query``."""
     needle = query.casefold().strip()
     requested_tags = {tag.casefold() for tag in tags or []}
     if (

--- a/pwnv/utils/guards.py
+++ b/pwnv/utils/guards.py
@@ -1,12 +1,4 @@
 def _guard(predicate, msg, *, empty_is_data=False):
-    """
-    Refuse to run a command whose precondition is not met.
-
-    ``empty_is_data`` marks a guard that only checks for records to report on.
-    Those commands still run under ``--json``, because the JSON contract says an
-    empty workspace is an empty list and exit code 0, not an error - a script
-    piping into `jq` should not have to tell "nothing here" apart from a crash.
-    """
     from functools import wraps
 
     import typer
@@ -52,9 +44,6 @@ def challenges_exists():
 
 def plugins_exists():
     def _any_plugins() -> bool:
-        # Resolved per call rather than when the decorator is built: the manager
-        # is a singleton, and binding it at import time would pin the guard to
-        # whichever instance existed when the command module was first loaded.
         from pwnv.core import plugin_manager
 
         return bool(plugin_manager.get_all_plugins())

--- a/pwnv/utils/plugin.py
+++ b/pwnv/utils/plugin.py
@@ -27,19 +27,10 @@ def get_templates_directory() -> Path:
 
 
 def get_bundled_examples_directory() -> Path:
-    """Where the plugins and templates that ship with pwnv live."""
     return Path(__file__).resolve().parent.parent / DEFAULT_EXAMPLES_FOLDER_NAME
 
 
 def install_bundled_examples() -> List[Path]:
-    """
-    Seed the workspace with the plugins and templates pwnv ships.
-
-    A fresh workspace with no plugins at all means `pwnv challenge add` only
-    creates an empty directory, which is a poor first impression and gives
-    nothing to copy when writing your own. Files that already exist are skipped
-    rather than overwritten, so this never clobbers an edited plugin.
-    """
     import shutil
 
     source = get_bundled_examples_directory()
@@ -70,7 +61,6 @@ def install_bundled_examples() -> List[Path]:
 
 
 def _apply_bundled_selection(source: Path) -> None:
-    """Select the bundled plugins for categories that have nothing selected."""
     import json
 
     bundled = source / DEFAULT_PLUGINS_FOLDER_NAME / DEFAULT_SELECTION_FILE_NAME

--- a/pwnv/utils/remote.py
+++ b/pwnv/utils/remote.py
@@ -361,7 +361,7 @@ async def get_remote_credential_methods(
     try:
         client: Any = await open_client(url, platform)
     except Exception as exc:
-        from pwnv.utils.ui import command, debug_traceback, error, info
+        from pwnv.utils.ui import command, error, info
 
         error(f"Could not open a client for {url}: {exc}")
         if not platform:
@@ -369,7 +369,6 @@ async def get_remote_credential_methods(
                 "If the platform was not recognised, name it: "
                 f"{command('pwnv ctf add NAME --url URL --platform rctf')}."
             )
-        debug_traceback()
         return None, None
     methods = await client.auth.get_supported_auth_methods()
     return client, methods
@@ -386,10 +385,9 @@ async def create_remote_session(
         await client.session.save(str(ctf.path / ".session"))
         return True
     except Exception:
-        from pwnv.utils.ui import debug_traceback, error
+        from pwnv.utils.ui import error
 
         error("Failed to authenticate with the provided credentials.")
-        debug_traceback()
         return False
 
 
@@ -400,10 +398,9 @@ async def get_remote_challenges(client: Any, ctf: CTF):
         challenges = await client.challenges.get_all()
         return challenges
     except Exception:
-        from pwnv.utils.ui import debug_traceback, error
+        from pwnv.utils.ui import error
 
         error("Failed to fetch challenges.")
-        debug_traceback()
         return None
 
 
@@ -550,10 +547,7 @@ async def add_remote_challenges(
             try:
                 ch = await client.attachments.download_all(ch, save_dir=path)
             except Exception:
-                from pwnv.utils.ui import debug_traceback
-
                 warn(f"Skipped attachments for {name}")
-                debug_traceback()
             attachments = _fingerprint_attachments(
                 getattr(ch, "attachments", None) or []
             )
@@ -679,8 +673,7 @@ async def remote_solve(ctf: CTF, challenge: Challenge, flag: str) -> bool:
         except Exception:
             pass
 
-    from pwnv.utils.ui import debug_traceback, error
+    from pwnv.utils.ui import error
 
     error(f"Failed to submit flag '{flag}'.")
-    debug_traceback()
     return False

--- a/pwnv/utils/remote.py
+++ b/pwnv/utils/remote.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Tuple
 from pwnv.models import CTF, Challenge
 from pwnv.models.challenge import Category
 
-_keyword_map: "list[tuple[str, Category]]" = [
+_keyword_map = [
     ("web exploitation", Category.web),
     ("web exploit", Category.web),
     ("binary exploitation", Category.pwn),
@@ -143,9 +143,7 @@ def _load_credentials(path: Path) -> Dict[str, str | None]:
 
 
 def protect_ctf_secrets(ctf_path: Path) -> None:
-    """
-    Drop a ``.gitignore`` next to a CTF's credentials.
-    """
+    """Drop a ``.gitignore`` next to a CTF's credentials."""
     gitignore = ctf_path / ".gitignore"
     entries = (".env", ".session", ".venv/", ".pwnvenv/")
     try:
@@ -248,11 +246,7 @@ _EMPTY_SUMMARY: Dict[str, Any] = {
 def sync_remote_ctf(
     ctf: CTF, *, refresh_attachments: bool = False, report: bool = True
 ) -> Dict[str, Any] | None:
-    """
-    Fetch new challenges for ``ctf`` from its remote platform.
-
-    Returns a summary of what changed, or ``None`` when the sync failed.
-    """
+    """Fetch new challenges for ``ctf`` and return a summary of what changed."""
     from pwnv.utils.ui import info, warn
 
     if not ctf.url:
@@ -330,21 +324,14 @@ def _retry_with_stored_credentials(client: Any, ctf: CTF):
 
 
 def known_platforms() -> list[str]:
-    """The platform names ctfbridge can be pinned to, in alphabetical order."""
+    """Return the platform names ctfbridge can be pinned to, alphabetical."""
     from ctfbridge.platforms.registry import PLATFORM_CLIENTS
 
     return sorted(PLATFORM_CLIENTS)
 
 
 async def open_client(url: str, platform: str | None = None) -> Any:
-    """
-    Connect to ``url``, detecting the platform unless one was pinned.
-
-    ctfbridge sniffs the platform from the site, and the sniff is a guess: an
-    instance behind a proxy, or one whose landing page was themed, can come out
-    as the wrong platform or as none at all. ``platform`` is the way past that,
-    and it is stored on the CTF so every later sync uses it too.
-    """
+    """Connect to ``url``, detecting the platform unless one was pinned."""
     from ctfbridge import create_client
 
     return await create_client(url=url, platform=platform or "auto")
@@ -420,7 +407,7 @@ def _file_digest(path: Path) -> str | None:
         return None
 
 
-def _fingerprint_attachments(attachments) -> "list[dict]":
+def _fingerprint_attachments(attachments) -> list[dict]:
     """Dump attachments, recording a digest of whatever landed on disk."""
     dumped = []
     for attachment in attachments:
@@ -433,13 +420,7 @@ def _fingerprint_attachments(attachments) -> "list[dict]":
 
 
 def _attachments_are_current(remote, stored) -> bool:
-    """
-    Report whether every published attachment is already on disk, byte for byte.
-
-    Platforms do not publish checksums, so the comparison is against a digest
-    pwnv recorded at download time. Size is checked first because it is free.
-    Re-downloading 40 MB of images on every poll is the thing to avoid here.
-    """
+    """Report whether every attachment is already on disk, byte for byte."""
     if not remote:
         return True
 
@@ -461,7 +442,7 @@ def _attachments_are_current(remote, stored) -> bool:
     return True
 
 
-def _unique_challenge_path(preferred: Path, taken: "list[Challenge]") -> Path:
+def _unique_challenge_path(preferred: Path, taken: list[Challenge]) -> Path:
     """Return ``preferred``, suffixed if another challenge already claims it."""
     claimed = {item.path for item in taken}
     if preferred not in claimed:
@@ -481,12 +462,7 @@ async def add_remote_challenges(
     refresh_attachments: bool = False,
     report: bool = True,
 ) -> Dict[str, Any]:
-    """
-    Create or update fetched challenges and download their attachments.
-
-    Returns a summary of what changed so callers can show a diff instead of
-    replaying every challenge on every sync.
-    """
+    """Create or update fetched challenges and download their attachments."""
     from pwnv.models import Challenge
     from pwnv.models.challenge import Solved
     from pwnv.utils.crud import add_challenge, challenges_for_ctf, update_challenge

--- a/pwnv/utils/selection.py
+++ b/pwnv/utils/selection.py
@@ -1,18 +1,9 @@
-"""Helpers for resolving explicit or interactive CLI selections."""
-
 from typing import List, Sequence
 
 from pwnv.models import Challenge
 
 
 def _narrow_to_likeliest(matches: List[Challenge]) -> List[Challenge]:
-    """
-    Drop matches you almost certainly did not mean.
-
-    Names collide constantly across CTFs - every event has a "sanity" and half
-    of them have a "baby rop". The CTF you are standing in wins, then running
-    CTFs, and only a genuine tie reaches the picker.
-    """
     from pwnv.utils.crud import get_current_ctf, get_running_ctfs
 
     if len(matches) < 2:
@@ -27,7 +18,6 @@ def _narrow_to_likeliest(matches: List[Challenge]) -> List[Challenge]:
 
 
 def _matching(scope: Sequence[Challenge], name: str) -> List[Challenge]:
-    """Find challenges called ``name``, loosening the comparison as needed."""
     from pwnv.utils.remote import sanitize
 
     needle = name.strip()
@@ -52,7 +42,6 @@ def resolve_challenge(
     challenges: Sequence[Challenge] | None = None,
     prompt: str = "Select a challenge:",
 ) -> Challenge:
-    """Resolve a challenge by scope, current directory, or interactive selection."""
     import typer
 
     from pwnv.utils.crud import (

--- a/pwnv/utils/serialize.py
+++ b/pwnv/utils/serialize.py
@@ -1,11 +1,4 @@
-"""Canonical JSON shapes for the objects the CLI reports on.
-
-Every ``--json`` flag renders through here, so a challenge looks the same
-whether it arrived from ``challenge info``, ``challenge search`` or something
-written later. The values are plain JSON types - enums by name, ids and paths as
-strings, solve state as a bool - because the reader is another program rather
-than a person.
-"""
+"""Canonical JSON payloads for the CLI's ``--json`` output."""
 
 from __future__ import annotations
 
@@ -22,7 +15,6 @@ def _extras(challenge: Challenge) -> dict:
 
 
 def _mappings(value: Any) -> List[dict]:
-    """Keep the mappings out of a stored list, whatever else ended up in it."""
     if not isinstance(value, list):
         return []
     return [item for item in value if isinstance(item, dict)]
@@ -31,12 +23,7 @@ def _mappings(value: Any) -> List[dict]:
 def challenge_payload(
     challenge: Challenge, *, ctf_names: Dict[Any, str] | None = None
 ) -> Dict[str, Any]:
-    """
-    Render one challenge as JSON-safe data.
-
-    ``ctf_names`` lets a caller resolve the owning CTF once for a whole list
-    instead of rescanning the config per challenge.
-    """
+    """Render one challenge as JSON-safe data; ``ctf_names`` maps CTF ids to names."""
     if ctf_names is None:
         from pwnv.utils.crud import get_ctfs
 
@@ -62,7 +49,7 @@ def challenge_payload(
 
 
 def challenges_payload(challenges: Sequence[Challenge]) -> List[Dict[str, Any]]:
-    """Render a list of challenges, resolving CTF names once."""
+    """Render a list of challenges as JSON-safe data."""
     from pwnv.utils.crud import get_ctfs
 
     ctf_names = {ctf.id: ctf.name for ctf in get_ctfs()}
@@ -84,7 +71,7 @@ def _ctf_payload(ctf: CTF, challenges: int, solved: int) -> Dict[str, Any]:
 
 
 def ctf_payload(ctf: CTF) -> Dict[str, Any]:
-    """Render one CTF, including the challenge counts a caller would tally."""
+    """Render one CTF with its challenge counts."""
     from pwnv.utils.crud import challenges_for_ctf
 
     challenges = challenges_for_ctf(ctf)
@@ -94,13 +81,11 @@ def ctf_payload(ctf: CTF) -> Dict[str, Any]:
 
 
 def ctfs_payload(ctfs: Sequence[CTF]) -> List[Dict[str, Any]]:
-    """Render several CTFs, counting the challenge list once for all of them."""
+    """Render a list of CTFs with challenge counts."""
     from collections import Counter
 
     from pwnv.utils.crud import get_challenges
 
-    # `challenges_for_ctf` rebuilds every challenge in the workspace from the
-    # config, so calling it per CTF made this quadratic in the number of records.
     challenges = get_challenges()
     totals = Counter(item.ctf_id for item in challenges)
     solved = Counter(item.ctf_id for item in challenges if item.solved)
@@ -124,14 +109,14 @@ def _plugin_payload(
 
 
 def plugin_payload(plugin: ChallengePlugin) -> Dict[str, Any]:
-    """Render one plugin, minus its source - that is what the file path is for."""
+    """Render one plugin as JSON-safe data."""
     from pwnv.utils.plugin import get_plugin_selection, get_plugins_directory
 
     return _plugin_payload(plugin, get_plugin_selection(), get_plugins_directory())
 
 
 def plugins_payload(plugins: Sequence[ChallengePlugin]) -> List[Dict[str, Any]]:
-    """Render several plugins, reading the selection and the directory once."""
+    """Render a list of plugins as JSON-safe data."""
     from pwnv.utils.plugin import get_plugin_selection, get_plugins_directory
 
     selection = get_plugin_selection()

--- a/pwnv/utils/template.py
+++ b/pwnv/utils/template.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import re
 from typing import Any
 
@@ -63,7 +62,8 @@ def _resolve_template_value(context: dict[str, Any], key: str) -> Any | None:
 
 
 def render_template(text: str, challenge: Challenge) -> str:
-    """Replace {{placeholders}} in template text using challenge metadata."""
+    import json
+
     context = _build_template_context(challenge)
 
     def _replace(match: re.Match[str]) -> str:

--- a/pwnv/utils/ui.py
+++ b/pwnv/utils/ui.py
@@ -17,17 +17,6 @@ _diagnostic_console: "Console | None" = None
 
 
 def _diagnostics() -> "Console":
-    """
-    The console that notices, warnings and errors are written on.
-
-    stdout is a data channel: ``pwncd`` expands to ``cd "$(pwnv challenge
-    path)"`` and ``--json`` output gets piped into other tools, so a passing
-    remark on stdout corrupts the result. Diagnostics go to stderr instead,
-    where a human still sees them and a parser does not.
-
-    ``stderr=True`` resolves ``sys.stderr`` on every write, so the redirect in
-    :func:`prompt_on_tty` and the capture in tests both keep working.
-    """
     global _diagnostic_console
 
     if _diagnostic_console is None:
@@ -100,14 +89,7 @@ _stdout_is_captured = False
 
 @contextmanager
 def prompt_on_tty() -> Generator[IO[str]]:
-    """
-    Route prompts and messages to the terminal, yielding the untouched stdout.
-
-    ``pwncd`` expands to ``cd "$(pwnv challenge path)"``, so stdout is a pipe. A
-    selector drawn there would be captured instead of displayed and the shell
-    would look like it hung, so the interface goes to the tty and only the
-    answer is written to stdout.
-    """
+    # pwncd pipes stdout; the UI goes to the tty, only the answer to stdout
     global _stdout_is_captured
 
     import contextlib
@@ -125,13 +107,6 @@ def prompt_on_tty() -> Generator[IO[str]]:
 
 @contextmanager
 def _prompt_session() -> Generator[None]:
-    """
-    Draw the next prompt on the terminal when stdout has been captured.
-
-    Claiming the tty is deferred until something actually prompts: doing it up
-    front makes prompt_toolkit complain about a non-interactive stdin on every
-    `pwncd`, which resolves without asking anything most of the time.
-    """
     import contextlib
 
     if not _stdout_is_captured:
@@ -221,7 +196,6 @@ def prompt_text(msg: str, **kwargs) -> str:
 
 
 def format_service(service: dict) -> str:
-    """Render one fetched service as the string you would actually connect with."""
     if not isinstance(service, dict):
         return str(service)
     if service.get("url"):
@@ -233,12 +207,6 @@ def format_service(service: dict) -> str:
 
 
 def render_sync_summary(ctf_name: str, summary: dict, *, quiet: bool = False) -> None:
-    """
-    Print what a sync changed rather than replaying the whole scoreboard.
-
-    During a live event the interesting part is the delta: what unlocked, what
-    got repriced by dynamic scoring, and what a teammate already solved.
-    """
     from rich import print
 
     added = summary.get("added") or []

--- a/pwnv/utils/ui.py
+++ b/pwnv/utils/ui.py
@@ -57,32 +57,6 @@ def command(msg: str):
     return f"[cyan]`{msg}`[/]"
 
 
-def debug_enabled() -> bool:
-    """Report whether ``PWNV_DEBUG`` is set to something that means yes."""
-    import os
-
-    from pwnv.constants import PWNV_DEBUG_ENV
-
-    return os.getenv(PWNV_DEBUG_ENV, "").strip().lower() not in ("", "0", "false", "no")
-
-
-def debug_traceback() -> None:
-    """
-    Print the exception being handled, when ``PWNV_DEBUG`` is set.
-
-    A command that swallows an exception to print a sentence instead is right
-    for an event and useless for a bug report: "Failed to fetch challenges."
-    says nothing about which platform call failed. Set ``PWNV_DEBUG=1`` to get
-    the traceback alongside the sentence, on stderr with the other diagnostics.
-    """
-    import sys
-    import traceback
-
-    if not debug_enabled() or sys.exc_info()[0] is None:
-        return
-    _diagnostics().print("[dim]" + escape(traceback.format_exc().rstrip()) + "[/]")
-
-
 def _get_challenge_choices(challenges: Sequence[Challenge]):
     from InquirerPy.base.control import Choice
 

--- a/pwnv/utils/venv.py
+++ b/pwnv/utils/venv.py
@@ -1,18 +1,14 @@
-"""Helpers for the uv-managed virtual environments pwnv creates."""
-
 from pathlib import Path
 
 from pwnv.constants import DEFAULT_PWNVENV_FOLDER_NAME
 
 
 def venv_python(environment: Path) -> Path:
-    """Return the interpreter path inside a uv virtual environment."""
     windows = environment / "Scripts" / "python.exe"
     return windows if windows.exists() else environment / "bin" / "python"
 
 
 def ctf_env_path(ctfs_path: Path | None = None) -> Path:
-    """Return the path of the shared CTF virtual environment."""
     if ctfs_path is None:
         from pwnv.utils.config import get_ctfs_path
 
@@ -21,12 +17,6 @@ def ctf_env_path(ctfs_path: Path | None = None) -> Path:
 
 
 def installed_packages(python_path: Path) -> set[str] | None:
-    """
-    Return the normalised names of packages installed for ``python_path``.
-
-    ``None`` is returned when uv is unavailable or the environment cannot be
-    inspected.
-    """
     import json
     import shutil
     import subprocess

--- a/pwnv/utils/workspace.py
+++ b/pwnv/utils/workspace.py
@@ -1,5 +1,3 @@
-"""Backup and portability helpers for pwnv workspaces."""
-
 import json
 import tarfile
 from pathlib import Path
@@ -11,12 +9,10 @@ _VENV_DIR_NAMES = (DEFAULT_PWNVENV_FOLDER_NAME, ".venv")
 
 
 def _is_virtualenv_artifact(path: Path) -> bool:
-    """Return ``True`` if ``path`` lives inside a generated virtualenv."""
     return any(name in path.parts for name in _VENV_DIR_NAMES)
 
 
 def backup_workspace(destination: Path) -> Path:
-    """Create a complete ``tar.gz`` backup and return its final path."""
     from pwnv.utils.config import get_config_path, get_ctfs_path
 
     destination = destination.expanduser().resolve()
@@ -44,9 +40,6 @@ def backup_workspace(destination: Path) -> Path:
 def restore_workspace(
     source: Path, *, replace: bool = False, force: bool = False
 ) -> dict[str, int]:
-    """
-    Restore a ``workspace backup`` archive into the current workspace.
-    """
     import tempfile
 
     from pwnv.utils.config import get_ctfs_path
@@ -81,7 +74,6 @@ def restore_workspace(
 
 
 def _copy_tree(source_root: Path, destination_root: Path, *, force: bool) -> int:
-    """Copy the archived tree into place and report how many files landed."""
     import shutil
 
     if not source_root.is_dir():
@@ -105,9 +97,6 @@ def _copy_tree(source_root: Path, destination_root: Path, *, force: bool) -> int
 def _rebase_by_layout(
     imported: Init, source_root: Path, destination_root: Path
 ) -> None:
-    """
-    Move every record to the same place under the new CTF root.
-    """
     from pwnv.utils.remote import sanitize
 
     ctf_paths: dict = {}
@@ -135,15 +124,6 @@ def _rebase_by_layout(
 def _rebase_attachments(
     challenge: Challenge, source_root: Path | None, destination_root: Path
 ) -> None:
-    """
-    Point downloaded attachments at the copies that travelled with the archive.
-
-    The files move with the challenge directory, but ``local_path`` is recorded
-    as an absolute path, so without this a solve script on the new machine reads
-    a path from the old one. An attachment stored outside the CTF root - or
-    arriving from an export, which carries no files at all - lands in the
-    challenge directory, where a re-download would put it.
-    """
     extras = challenge.extras if isinstance(challenge.extras, dict) else {}
     attachments = extras.get("attachments")
     if not isinstance(attachments, list):
@@ -162,7 +142,6 @@ def _rebase_attachments(
 
 
 def _relocate(path: Path, source_root: Path, destination_root: Path) -> Path | None:
-    """The same relative location under a different root, if there is one."""
     try:
         return destination_root / path.relative_to(source_root)
     except ValueError:
@@ -170,7 +149,6 @@ def _relocate(path: Path, source_root: Path, destination_root: Path) -> Path | N
 
 
 def export_workspace(destination: Path) -> Path:
-    """Export portable workspace metadata without challenge files or secrets."""
     import copy
 
     from pwnv.utils.config import load_config
@@ -192,16 +170,6 @@ def export_workspace(destination: Path) -> Path:
 
 
 def import_workspace(source: Path, *, replace: bool = False) -> dict[str, int]:
-    """
-    Import metadata, rebasing all workspace paths to the current CTF root.
-
-    By default the import is *merged* into the current workspace: CTFs and
-    challenges already present are left alone and only new records are added,
-    so importing a teammate's export cannot discard your own solves. Pass
-    ``replace=True`` for the previous behaviour of overwriting everything.
-
-    Returns a summary of how many records were added and skipped.
-    """
     from pwnv.utils.config import get_ctfs_path
 
     data = json.loads(source.expanduser().resolve().read_text(encoding="utf-8"))
@@ -213,12 +181,6 @@ def import_workspace(source: Path, *, replace: bool = False) -> dict[str, int]:
 
 
 def _rebase_by_name(imported: Init, ctfs_path: Path) -> None:
-    """
-    Point every record at the directory its name implies under ``ctfs_path``.
-
-    An export carries no files, so there is no layout to preserve: the
-    directories are recreated from the names, exactly as ``pwnv ctf add`` would.
-    """
     from pwnv.utils.remote import sanitize
 
     ctf_paths: dict = {}
@@ -242,7 +204,6 @@ def _rebase_by_name(imported: Init, ctfs_path: Path) -> None:
 
 
 def _merge_records(imported: Init, *, replace: bool) -> dict[str, int]:
-    """Fold ``imported`` into the stored configuration, skipping duplicates."""
     from pwnv.utils.config import config_transaction
 
     summary = {
@@ -270,16 +231,11 @@ def _merge_records(imported: Init, *, replace: bool) -> dict[str, int]:
         ctf_id_by_name = {item["name"]: str(item["id"]) for item in existing_ctfs}
         known_challenge_ids = {str(item["id"]) for item in existing_challenges}
         known_challenge_paths = {str(item["path"]) for item in existing_challenges}
-        # Incoming CTF id -> the id the same event already has here.
         adopted: dict[str, str] = {}
 
         for ctf_data in incoming.get("ctfs", []):
             incoming_id = str(ctf_data["id"])
             if incoming_id in known_ctf_ids or ctf_data["name"] in known_ctf_names:
-                # The event is already here, under an id of its own if it was
-                # created rather than imported. Its challenges are re-pointed at
-                # that record, because otherwise they belong to no CTF in this
-                # config and are dropped - after their files have been copied.
                 adopted[incoming_id] = ctf_id_by_name.get(ctf_data["name"], incoming_id)
                 summary["ctfs_skipped"] += 1
                 continue

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,14 +1,5 @@
 #!/usr/bin/env bash
-#
 # End-to-end check of the installed `pwnv` command.
-#
-# The test suite runs from the source tree with a monkeypatched config, so it
-# never sees the two things that break for a user first: files that did not make
-# it into the wheel, and commands that only work when a real workspace is on
-# disk. This drives the actual binary through a full lifecycle instead - set up,
-# add, inspect, back up, move to a second machine - and asserts on the files and
-# JSON that come out.
-#
 # Usage: scripts/smoke.sh [python-version]
 set -euo pipefail
 
@@ -33,10 +24,7 @@ exists() {
   fi
 }
 
-# Assert that a JSON document satisfies a Python expression, with the parsed
-# document bound to `d`. The document is an argument rather than stdin: a shell
-# function on the right of a pipe runs in a subshell, so every failure it
-# counted would be discarded when that subshell exits.
+# The document is an argument: piping into the function would run it in a subshell and drop FAILURES.
 expect_json() {
   local description="$1" expression="$2" document="$3"
   if printf '%s' "$document" |
@@ -63,8 +51,6 @@ pwnv init --yes --no-install --python "$PYTHON_VERSION" --ctfs-folder "$CTFS"
 
 exists "$PWNV_CONFIG" "config written"
 exists "$CTFS/.pwnvenv" "CTF environment created"
-# The bundled examples live in package data. If a packaging change drops them,
-# every test still passes and `pwnv init` silently stops shipping templates.
 exists "$WORKDIR/old/templates" "templates folder created"
 if compgen -G "$WORKDIR/old/templates/*" >/dev/null; then
   ok "bundled templates installed from package data"
@@ -77,8 +63,6 @@ else
   fail "bundled plugins installed from package data"
 fi
 
-# Assert that a command fails, and says why. `set -e` would otherwise abort the
-# run on the first refusal, which is exactly the behaviour being checked here.
 expect_failure() {
   local description="$1"
   shift
@@ -96,7 +80,6 @@ step "ctf add / challenge add"
 pwnv ctf add smoke --local
 pwnv challenge add babyrop --ctf smoke --category pwn
 
-# A refusal has to be visible to `set -e`, not just to the person reading along.
 expect_failure "adding the same CTF twice fails" pwnv ctf add smoke --local
 expect_failure "an unknown platform is rejected" \
   pwnv ctf add other --url https://ctf.invalid --platform notaplatform
@@ -169,7 +152,6 @@ esac
 exists "$NEW_DIR/NOTES.md" "notes travelled with the archive"
 exists "$NEW_DIR/solve.py" "solve script travelled with the archive"
 
-# Restoring the same archive twice must not duplicate anything.
 pwnv workspace restore "$WORKDIR/move.tar.gz" >/dev/null
 STATUS_JSON="$(pwnv status --json)"
 expect_json "restoring twice is a no-op" \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,6 @@ import pytest
 
 
 def _reload_modules(module_names: Iterable[str]) -> None:
-    """Reload pwnv modules so they pick up fresh environment variables."""
     importlib.invalidate_caches()
     for name in module_names:
         if name in sys.modules:
@@ -16,10 +15,6 @@ def _reload_modules(module_names: Iterable[str]) -> None:
             importlib.import_module(name)
 
 
-# Modules that cache the config path at import time, in dependency order.
-# `pwnv.core` comes last on purpose: it re-exports the plugin_manager singleton,
-# so reloading the submodule alone leaves every `from pwnv.core import
-# plugin_manager` caller holding the previous test's instance.
 _RELOADED_MODULES = (
     "pwnv.utils.config",
     "pwnv.utils.plugin",
@@ -34,11 +29,6 @@ _RELOADED_MODULES = (
 
 @pytest.fixture(autouse=True)
 def isolated_config(monkeypatch, tmp_path):
-    """
-    Force pwnv to use an isolated config file under a temporary directory.
-
-    This prevents tests from touching the user's real config or CTF folders.
-    """
     cfg_dir = tmp_path / "pwnv_config_dir"
     cfg_dir.mkdir(parents=True, exist_ok=True)
     cfg_path = cfg_dir / "pwnv_config.json"
@@ -57,15 +47,11 @@ def isolated_config(monkeypatch, tmp_path):
         encoding="utf-8",
     )
 
-    # Make pwnv resolve all config paths inside our temp directory.
     monkeypatch.setenv("PWNV_CONFIG", str(cfg_path))
-
-    # Reload modules that cache the config path at import time.
     _reload_modules(_RELOADED_MODULES)
 
     yield cfg_path
 
-    # Clear cached config between tests.
     cfg_mod = sys.modules.get("pwnv.utils.config")
     if cfg_mod and hasattr(cfg_mod, "load_config"):
         cfg_mod.load_config.cache_clear()
@@ -73,12 +59,6 @@ def isolated_config(monkeypatch, tmp_path):
 
 @pytest.fixture
 def reload_pwnv_modules():
-    """
-    Helper fixture to force-reload pwnv modules on demand.
-
-    Useful in tests that change environment variables mid-test.
-    """
-
     def _reload():
         _reload_modules(_RELOADED_MODULES)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,8 +59,6 @@ def isolated_config(monkeypatch, tmp_path):
 
     # Make pwnv resolve all config paths inside our temp directory.
     monkeypatch.setenv("PWNV_CONFIG", str(cfg_path))
-    # Ensure debug override is off.
-    monkeypatch.delenv("PWNV_DEBUG", raising=False)
 
     # Reload modules that cache the config path at import time.
     _reload_modules(_RELOADED_MODULES)

--- a/tests/test_api_and_json.py
+++ b/tests/test_api_and_json.py
@@ -1,5 +1,3 @@
-"""Tests for the solve-script object and the machine-readable output contract."""
-
 import json
 import os
 import subprocess
@@ -14,10 +12,6 @@ from pwnv.models import CTF, Challenge
 from pwnv.models.challenge import Category, Solved
 from pwnv.models.ctf import Status
 from pwnv.utils import add_challenge, add_ctf, get_ctfs_path
-
-# --------------------------------------------------------------------------- #
-# fixtures
-# --------------------------------------------------------------------------- #
 
 
 def _ctf(name: str, *, running: Status = Status.running, url: str | None = None) -> CTF:
@@ -55,10 +49,9 @@ def _update(challenge) -> None:
 
 
 def _strict_runner() -> CliRunner:
-    """A runner that keeps stderr out of stdout, so `--json` can be parsed."""
     try:
         return CliRunner(mix_stderr=False)
-    except TypeError:  # click >= 8.2 never mixes them
+    except TypeError:
         return CliRunner()
 
 
@@ -66,11 +59,6 @@ def _invoke(*args: str):
     from pwnv import app
 
     return _strict_runner().invoke(app, list(args))
-
-
-# --------------------------------------------------------------------------- #
-# resolution
-# --------------------------------------------------------------------------- #
 
 
 def test_it_resolves_the_challenge_you_are_standing_in(monkeypatch):
@@ -122,7 +110,6 @@ def test_a_path_can_be_asked_about_directly(monkeypatch, tmp_path):
 
 
 def test_it_sees_a_sync_that_ran_after_the_script_started(monkeypatch):
-    """The whole point: values bind when they are read, not when scaffolded."""
     from pwnv.api import current
     from pwnv.utils import get_challenges, update_challenge
 
@@ -139,13 +126,7 @@ def test_it_sees_a_sync_that_ran_after_the_script_started(monkeypatch):
     assert (moved.host, moved.port) == ("relocated.example.org", 31337)
 
 
-# --------------------------------------------------------------------------- #
-# it is a ctfbridge challenge
-# --------------------------------------------------------------------------- #
-
-
 def test_what_comes_back_is_the_platform_model(monkeypatch):
-    """No pwnv wrapper: the helpers a solve script uses are ctfbridge's own."""
     from ctfbridge.models.challenge import Challenge as BridgeChallenge
 
     from pwnv.api import current
@@ -199,7 +180,6 @@ def test_attachments_arrive_as_the_collection_with_their_local_paths(monkeypatch
     stored = next(item for item in _stored_challenges() if item.name == "Handout")
     stored.extras = {
         "attachments": [
-            # `sha256` is pwnv's own bookkeeping; the platform model ignores it.
             {"name": "vuln", "local_path": str(binary), "sha256": "deadbeef"}
         ]
     }
@@ -224,18 +204,7 @@ def test_solved_and_flag_come_from_the_local_record(monkeypatch):
     assert resolved.flag == "flag{x}"
 
 
-# --------------------------------------------------------------------------- #
-# import cost
-# --------------------------------------------------------------------------- #
-
-
 def test_importing_the_object_does_not_drag_in_the_cli(monkeypatch):
-    """
-    A solve script pays for what it uses.
-
-    Assembling the Typer app imports every command module; resolving a challenge
-    needs none of them, so `from pwnv import challenge` must not reach typer.
-    """
     ctf = _ctf("ApiCTF")
     challenge = _challenge(ctf, "Probe")
 
@@ -262,14 +231,6 @@ def test_importing_the_object_does_not_drag_in_the_cli(monkeypatch):
 
 
 def test_the_default_config_location_does_not_reach_for_typer(tmp_path):
-    """
-    The same assertion, on the branch an ordinary install actually takes.
-
-    With no `PWNV_CONFIG` and no config file above the working directory, the
-    path comes from the application directory - which used to be resolved with
-    `typer.get_app_dir`, so every solve script on a normal machine imported the
-    CLI after all. It is `click.get_app_dir`, which typer only re-exports.
-    """
     home = tmp_path / "home"
     (home / ".config").mkdir(parents=True)
     work = tmp_path / "work"
@@ -311,11 +272,6 @@ def test_the_default_config_location_does_not_reach_for_typer(tmp_path):
     assert result.stdout.strip().startswith(str(home))
 
 
-# --------------------------------------------------------------------------- #
-# the json contract
-# --------------------------------------------------------------------------- #
-
-
 def test_challenge_info_json_carries_the_whole_record(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     ctf = _ctf("JsonCTF")
@@ -344,7 +300,6 @@ def test_challenge_info_json_carries_the_whole_record(monkeypatch, tmp_path):
 
 
 def test_json_mode_reports_the_scope_instead_of_opening_a_picker(monkeypatch, tmp_path):
-    """There is nobody to answer a prompt on the other end of a pipe."""
     monkeypatch.chdir(tmp_path)
     ctf = _ctf("JsonCTF")
     _challenge(ctf, "One")
@@ -455,18 +410,7 @@ def test_status_json_still_parses_now_that_it_shares_the_flag(monkeypatch, tmp_p
     assert payload["ctfs"][0]["ctf"] == "JsonCTF"
 
 
-# --------------------------------------------------------------------------- #
-# stdout stays a data channel
-# --------------------------------------------------------------------------- #
-
-
 def test_diagnostics_never_land_in_the_data_channel(monkeypatch, tmp_path):
-    """
-    A warning printed on stdout would make `--json` output impossible to parse.
-
-    `challenge info --json` for a missing CTF must put the complaint on stderr
-    and nothing at all on stdout.
-    """
     monkeypatch.chdir(tmp_path)
     ctf = _ctf("JsonCTF")
     _challenge(ctf, "One")
@@ -500,12 +444,6 @@ def test_the_no_challenges_guard_writes_to_stderr(monkeypatch, tmp_path):
 def test_an_empty_workspace_is_an_empty_list_not_an_error(
     monkeypatch, tmp_path, argv, key
 ):
-    """
-    The guards that check for records must not fire in `--json` mode.
-
-    "There is nothing here" is an answer a script can act on; exit code 1 with
-    no document at all is one it has to tell apart from a crash.
-    """
     monkeypatch.chdir(tmp_path)
 
     result = _invoke(*argv)

--- a/tests/test_crud_local.py
+++ b/tests/test_crud_local.py
@@ -20,7 +20,6 @@ from pwnv.utils import (
 
 @pytest.fixture
 def fresh_ctf(tmp_path):
-    """Create and return a CTF model pointing to the isolated ctfs_path."""
     ctfs_path = get_ctfs_path()
     ctf_path = ctfs_path / "example_ctf"
     ctf = CTF(name="ExampleCTF", path=ctf_path)
@@ -47,14 +46,12 @@ def test_add_and_update_challenge(fresh_ctf):
     )
     add_challenge(challenge)
 
-    # Added to config and directory created
     challenges = get_challenges()
     assert len(challenges) == 1
     stored = challenges[0]
     assert stored.name == "First Blood"
     assert stored.path.exists() and stored.path.is_dir()
 
-    # Update metadata
     stored.solved = Solved.solved
     stored.flag = "FLAG{test}"
     stored.tags = ["pwn", "rop"]
@@ -67,7 +64,6 @@ def test_add_and_update_challenge(fresh_ctf):
 
 
 def test_remove_challenge_and_ctf_cascade(fresh_ctf):
-    # Add two challenges
     for name in ("Alpha", "Beta"):
         add_challenge(
             Challenge(
@@ -81,14 +77,12 @@ def test_remove_challenge_and_ctf_cascade(fresh_ctf):
 
     assert len(get_challenges()) == 2
 
-    # Remove one challenge
     to_remove = get_challenges()[0]
     remove_challenge(to_remove)
     remaining = get_challenges()
     assert len(remaining) == 1
     assert not to_remove.path.exists()
 
-    # Removing the CTF should delete remaining challenges and directory
     remove_ctf(fresh_ctf)
     assert get_ctfs() == []
     assert get_challenges() == []
@@ -98,7 +92,6 @@ def test_remove_challenge_and_ctf_cascade(fresh_ctf):
 def test_is_duplicate_by_name_and_path(fresh_ctf):
     duplicate_ctf = CTF(name="ExampleCTF", path=fresh_ctf.path)
     assert is_duplicate(model_list=get_ctfs(), path=duplicate_ctf.path)
-    # Different path but same name also considered duplicate
     other_path = get_ctfs_path() / "other_ctf"
     duplicate_ctf_other_path = CTF(name="ExampleCTF", path=other_path)
     assert is_duplicate(model_list=get_ctfs(), name=duplicate_ctf_other_path.name)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -33,28 +33,23 @@ def test_plugin_lookup_is_case_insensitive(tmp_path):
     )
     plugin_path.write_text(plugin_source, encoding="utf-8")
 
-    # Reset plugin manager caches so it loads our new plugin
     plugin_manager._loaded = False  # type: ignore[attr-defined]
     plugin_manager.get_all_plugins.cache_clear()  # type: ignore[attr-defined]
 
     plugins = plugin_manager.get_all_plugins()
     assert any(plugin_name(p) == "CustomMixedCase" for p in plugins)
 
-    # Case-insensitive direct lookup
     assert plugin_manager.get_plugin_by_name("custommixedcase") is not None
     assert plugin_manager.get_plugin_by_name("CUSTOMMIXEDCASE") is not None
 
-    # Selection respects stored name but lookup remains case-insensitive
     set_selected_plugin_for_category(Category.pwn, "custommixedcase")
     selected = get_selected_plugin_for_category(Category.pwn)
     assert selected is not None
     assert plugin_name(selected) == "CustomMixedCase"
 
-    # Verify the selection file stored exactly what we set
     selection = get_plugin_selection()
     assert selection[Category.pwn.name] == "custommixedcase"
 
-    # Changing selection casing still resolves to the same plugin
     save_plugin_selection({Category.pwn.name: "CUSTOMMIXEDCASE"})
     selected_again = get_selected_plugin_for_category(Category.pwn)
     assert selected_again is not None

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1,5 +1,3 @@
-"""Regression tests for defects that would bite during a live CTF."""
-
 import json
 import tarfile
 from pathlib import Path
@@ -21,7 +19,6 @@ from pwnv.utils import (
 
 
 def _remote_workspace():
-    """A CTF with a remote URL and one unsolved challenge."""
     ctf = CTF(
         name="RemoteCTF", path=get_ctfs_path() / "remotectf", url="https://ctf.invalid"
     )
@@ -39,7 +36,6 @@ def _remote_workspace():
 
 
 def test_rejected_flag_does_not_mark_challenge_solved(monkeypatch):
-    """A flag the platform rejects must not be recorded as a solve."""
     import pwnv.utils as utils
 
     _remote_workspace()
@@ -64,18 +60,15 @@ def test_rejected_flag_does_not_mark_challenge_solved(monkeypatch):
         ],
     )
 
-    # Non-zero exit so `pwnv solve ... && echo solved` cannot lie.
     assert result.exit_code == 1
     challenge = get_challenges()[0]
     assert challenge.solved == Solved.unsolved
     assert challenge.flag is None
-    # The attempt is still recorded for --history.
     assert len(challenge.extras["flag_history"]) == 1
     assert challenge.extras["flag_history"][0]["result"] == "rejected-or-failed"
 
 
 def test_challenge_remains_solvable_after_a_rejected_flag(monkeypatch):
-    """A typo must not lock the challenge out of `pwnv solve` forever."""
     import pwnv.utils as utils
 
     _remote_workspace()
@@ -106,7 +99,6 @@ def test_challenge_remains_solvable_after_a_rejected_flag(monkeypatch):
 
 
 def test_guard_failure_exits_non_zero():
-    """Guards must fail the process, not print a warning and return success."""
     from pwnv.utils.guards import _guard
 
     guarded = _guard(lambda: False, "nothing here")(lambda: "ran")
@@ -117,7 +109,6 @@ def test_guard_failure_exits_non_zero():
 
 
 def test_reset_only_removes_pwnv_artifacts():
-    """`pwnv reset` must never rmtree the config file's parent directory."""
     from pwnv.utils import get_config_path
 
     config_dir = get_config_path().parent
@@ -158,14 +149,12 @@ def test_reset_only_removes_pwnv_artifacts():
     ],
 )
 def test_category_normalisation(raw, expected):
-    """Real-world platform category labels map to the right Category."""
     from pwnv.utils import normalise_category
 
     assert normalise_category(raw) == expected
 
 
 def test_sync_keeps_the_platform_challenge_name():
-    """The scoreboard name must survive sync; only the directory is sanitized."""
     import asyncio
     from types import SimpleNamespace
 
@@ -200,7 +189,6 @@ def test_sync_keeps_the_platform_challenge_name():
 
 
 def test_backup_excludes_challenge_virtualenvs(tmp_path):
-    """Generated venvs must not be archived into every backup."""
     from pwnv.utils import backup_workspace
 
     ctf = CTF(name="VenvCTF", path=get_ctfs_path() / "venvctf")
@@ -231,7 +219,6 @@ def test_backup_excludes_challenge_virtualenvs(tmp_path):
 
 
 def test_import_merges_instead_of_discarding_local_work(tmp_path):
-    """Importing a teammate's export must not delete your own CTFs."""
     from pwnv.utils import import_workspace
 
     mine = CTF(name="MyCTF", path=get_ctfs_path() / "myctf")
@@ -283,11 +270,9 @@ def test_import_merges_instead_of_discarding_local_work(tmp_path):
     assert names == {"MyCTF", "TheirCTF"}
     assert summary["ctfs_added"] == 1
     assert summary["challenges_added"] == 1
-    # Local work is untouched and the imported challenge is rebased locally.
     challenges = {ch.name: ch for ch in get_challenges()}
     assert challenges["my-chal"].solved == Solved.solved
     assert challenges["their-chal"].path.is_relative_to(get_ctfs_path())
-    # Importing the same export twice is a no-op rather than a duplication.
     again = import_workspace(export_file)
     assert again["ctfs_added"] == 0
     assert again["challenges_added"] == 0
@@ -295,7 +280,6 @@ def test_import_merges_instead_of_discarding_local_work(tmp_path):
 
 
 def test_import_replace_still_available(tmp_path):
-    """`--replace` keeps the old destructive behaviour when asked for."""
     from pwnv.utils import export_workspace, import_workspace
 
     add_ctf(CTF(name="Original", path=get_ctfs_path() / "original"))
@@ -310,7 +294,6 @@ def test_import_replace_still_available(tmp_path):
 
 
 def test_current_challenge_resolves_after_a_directory_change(monkeypatch):
-    """Challenge lookup must use the live cwd, not the one frozen at import."""
     from pwnv.utils import crud
 
     ctf = CTF(name="CwdCTF", path=get_ctfs_path() / "cwdctf")
@@ -333,12 +316,10 @@ def test_current_challenge_resolves_after_a_directory_change(monkeypatch):
 
 
 def test_config_transaction_reads_fresh_state_under_the_lock():
-    """A transaction must not build on a stale cached read."""
     from pwnv.utils.config import config_transaction, get_config_path, load_config
 
-    load_config()  # prime the lru_cache
+    load_config()
 
-    # Simulate another pwnv process writing while our cache is warm.
     raw = json.loads(get_config_path().read_text(encoding="utf-8"))
     raw["challenge_tags"] = ["written-by-another-process"]
     get_config_path().write_text(json.dumps(raw), encoding="utf-8")
@@ -354,7 +335,6 @@ def test_config_transaction_reads_fresh_state_under_the_lock():
 
 
 def test_corrupt_config_reports_cleanly_instead_of_traceback():
-    """A truncated config must produce a readable error, not a JSONDecodeError."""
     from pwnv.utils.config import get_config_path, invalidate_cache, load_config
 
     get_config_path().write_text('{"ctfs": [', encoding="utf-8")
@@ -366,7 +346,6 @@ def test_corrupt_config_reports_cleanly_instead_of_traceback():
 
 
 def test_expired_session_is_retried_with_stored_credentials(tmp_path, monkeypatch):
-    """A session that goes stale mid-event must re-login, not just fail."""
     from pwnv.utils import remote as remote_mod
 
     ctf = CTF(
@@ -382,7 +361,6 @@ def test_expired_session_is_retried_with_stored_credentials(tmp_path, monkeypatc
 
     def _fake_fetch(client, ctf_arg):
         calls["fetch"] += 1
-        # First fetch fails as an expired cookie would; the retry succeeds.
         return None if calls["fetch"] == 1 else []
 
     async def _fetch(client, ctf_arg):
@@ -401,13 +379,11 @@ def test_expired_session_is_retried_with_stored_credentials(tmp_path, monkeypatc
     monkeypatch.setattr(remote_mod, "get_remote_credential_methods", _methods)
 
     assert remote_mod.sync_remote_ctf(ctf) is not None
-    # One login for the initial .env auth, one for the expiry retry.
     assert calls["login"] == 2
     assert calls["fetch"] == 2
 
 
 def test_ctf_directory_gets_a_gitignore_for_secrets():
-    """Credentials and cookie jars must not be committable by accident."""
     from pwnv.utils.remote import protect_ctf_secrets
 
     ctf = CTF(name="ShareCTF", path=get_ctfs_path() / "sharectf")
@@ -418,7 +394,6 @@ def test_ctf_directory_gets_a_gitignore_for_secrets():
     assert ".env" in entries
     assert ".session" in entries
 
-    # Running again is idempotent and preserves anything already there.
     (ctf.path / ".gitignore").write_text("custom-entry\n", encoding="utf-8")
     protect_ctf_secrets(ctf.path)
     entries = (ctf.path / ".gitignore").read_text(encoding="utf-8").split()
@@ -427,7 +402,6 @@ def test_ctf_directory_gets_a_gitignore_for_secrets():
 
 
 def test_plugin_module_does_not_shadow_stdlib(tmp_path):
-    """A plugin named after a stdlib module must not hijack that import."""
     import sys
 
     from pwnv.core.plugin_manager import PluginManager, plugin_name
@@ -451,18 +425,16 @@ def test_plugin_module_does_not_shadow_stdlib(tmp_path):
     manager = PluginManager()
     manager.discover_and_load_plugins()
 
-    # The real stdlib json is still importable and intact.
     import json as json_module
 
     assert sys.modules["json"] is json_module
     assert hasattr(json_module, "dumps")
 
     loaded = [p for p in manager.get_all_plugins() if plugin_name(p) == "json"]
-    assert loaded, "the plugin should still load under its own name"
+    assert loaded
 
 
 def test_local_challenge_flag_submission_reports_missing_remote_id(monkeypatch):
-    """A locally-created challenge explains itself instead of failing mutely."""
     import asyncio
 
     from pwnv.utils.remote import remote_solve
@@ -487,7 +459,6 @@ def test_local_challenge_flag_submission_reports_missing_remote_id(monkeypatch):
 
 
 def test_sync_keeps_challenges_whose_names_sanitize_identically():
-    """Distinct platform challenges must not collapse into one record."""
     import asyncio
     from types import SimpleNamespace
 
@@ -521,16 +492,13 @@ def test_sync_keeps_challenges_whose_names_sanitize_identically():
     challenges = get_challenges()
     assert len(challenges) == 3
     assert {ch.extras["slug"] for ch in challenges} == {"id-1", "id-2", "id-3"}
-    # Each gets its own directory rather than sharing one.
     assert len({ch.path for ch in challenges}) == 3
 
-    # Re-syncing matches on the remote id, so nothing is duplicated.
     asyncio.run(add_remote_challenges(client, ctf, remote))
     assert len(get_challenges()) == 3
 
 
 def test_local_ctf_ignores_ambient_platform_credentials(monkeypatch):
-    """Exported PWNV_CTF_* must not block `ctf add --local`."""
     monkeypatch.setenv("PWNV_CTF_USERNAME", "player")
     monkeypatch.setenv("PWNV_CTF_PASSWORD", "hunter2")
 
@@ -541,7 +509,6 @@ def test_local_ctf_ignores_ambient_platform_credentials(monkeypatch):
 
 
 def test_empty_selector_reports_instead_of_raising():
-    """An empty candidate list must not surface InquirerPy's InvalidArgument."""
     from pwnv.utils.ui import prompt_challenge_selection
 
     with pytest.raises(typer.Exit) as excinfo:
@@ -550,7 +517,6 @@ def test_empty_selector_reports_instead_of_raising():
 
 
 def test_remove_commands_are_scriptable():
-    """`--yes` lets removal run unattended."""
     ctf = CTF(name="ScriptCTF", path=get_ctfs_path() / "scriptctf")
     add_ctf(ctf)
     challenge = Challenge(
@@ -574,7 +540,6 @@ def test_remove_commands_are_scriptable():
 
 
 def test_search_with_only_a_scope_lists_that_scope():
-    """`challenge search --ctf X` must list X, not return nothing."""
     ctf = CTF(name="ScopeCTF", path=get_ctfs_path() / "scopectf")
     add_ctf(ctf)
     add_challenge(
@@ -604,7 +569,6 @@ def test_search_with_only_a_scope_lists_that_scope():
 
 
 def _teammate_export(ctf_name: str, ctf_id: str, challenge_name: str) -> dict:
-    """An export as another machine would write it, rooted somewhere else."""
     return {
         "ctfs_path": "/somewhere/else",
         "challenge_tags": [],
@@ -636,13 +600,6 @@ def _teammate_export(ctf_name: str, ctf_id: str, challenge_name: str) -> dict:
 
 
 def test_import_adopts_challenges_of_a_ctf_already_in_the_workspace(tmp_path):
-    """
-    Two people at the same event have the same CTF under two different ids.
-
-    The CTF is skipped as a duplicate, and its challenges used to be skipped
-    with it - they referred to an id this config had never heard of - so the
-    import silently added nothing at all.
-    """
     from pwnv.utils import import_workspace
 
     mine = CTF(name="SharedCTF", path=get_ctfs_path() / "sharedctf")
@@ -664,12 +621,10 @@ def test_import_adopts_challenges_of_a_ctf_already_in_the_workspace(tmp_path):
     assert summary["challenges_added"] == 1
     challenges = get_challenges()
     assert [ch.name for ch in challenges] == ["their-chal"]
-    # Adopted by the CTF that was already here, not by the id in the export.
     assert challenges[0].ctf_id == mine.id
 
 
 def _backup_from_another_machine(tmp_path, old_root: str) -> Path:
-    """Write an archive whose config was recorded under ``old_root``."""
     config = {
         "ctfs_path": old_root,
         "challenge_tags": [],
@@ -723,7 +678,6 @@ def _backup_from_another_machine(tmp_path, old_root: str) -> Path:
 
 
 def test_restore_rebases_downloaded_attachments(tmp_path):
-    """An attachment must point at the copy that travelled with the archive."""
     from pwnv.utils import restore_workspace
 
     archive = _backup_from_another_machine(tmp_path, "/old/machine/CTFs")
@@ -737,7 +691,6 @@ def test_restore_rebases_downloaded_attachments(tmp_path):
 
 
 def test_restoring_something_that_is_not_an_archive_reports_cleanly(tmp_path):
-    """A wrong file must produce a message, not a tarfile traceback."""
     bogus = tmp_path / "notes.tar.gz"
     bogus.write_text("these are notes, not a tarball", encoding="utf-8")
 
@@ -749,7 +702,6 @@ def test_restoring_something_that_is_not_an_archive_reports_cleanly(tmp_path):
 
 
 def test_an_add_that_was_refused_exits_non_zero():
-    """A script running under `set -e` has to notice a command that failed."""
     runner = CliRunner()
     ctf = CTF(name="Dup", path=get_ctfs_path() / "dup")
     add_ctf(ctf)

--- a/tests/test_remote_ctf.py
+++ b/tests/test_remote_ctf.py
@@ -310,32 +310,3 @@ def test_sync_pins_the_platform_on_the_ctf(monkeypatch):
 
     assert result.exit_code == 0
     assert get_ctfs()[0].platform == "rctf"
-
-
-@pytest.mark.parametrize(
-    ("value", "shown"),
-    [("1", True), ("0", False), ("", False)],
-)
-def test_pwnv_debug_decides_whether_the_traceback_is_printed(
-    monkeypatch, capsys, value, shown
-):
-    """The sentence is for an event, the traceback is for a bug report."""
-    from pwnv.utils import debug_traceback
-
-    monkeypatch.setenv("PWNV_DEBUG", value)
-    try:
-        raise RuntimeError("the underlying reason")
-    except RuntimeError:
-        debug_traceback()
-
-    assert ("the underlying reason" in capsys.readouterr().err) is shown
-
-
-def test_the_traceback_is_skipped_when_nothing_was_raised(monkeypatch, capsys):
-    """Called outside a handler it must print nothing, not `NoneType: None`."""
-    from pwnv.utils import debug_traceback
-
-    monkeypatch.setenv("PWNV_DEBUG", "1")
-    debug_traceback()
-
-    assert capsys.readouterr().err == ""

--- a/tests/test_remote_ctf.py
+++ b/tests/test_remote_ctf.py
@@ -124,17 +124,10 @@ def test_sanitize_produces_safe_challenge_names(name, expected):
     ),
 )
 def test_add_remote_ctf_integration(monkeypatch, isolated_config):
-    """
-    Minimal integration test against the public demo CTFd instance.
-
-    The test is opt-in via ENABLE_REMOTE_CTFS=1 and runs entirely in the
-    isolated config/ctfs path provided by the tests fixture.
-    """
     url = "https://demo.ctfd.io/"
     username = os.getenv("DEMO_CTFD_USER", "user")
     password = os.getenv("DEMO_CTFD_PASS", "password")
 
-    # Force deterministic, non-interactive credential prompts.
     def _dummy_prompt(value):
         class _P:
             def execute(self_nonlocal):
@@ -170,21 +163,19 @@ def test_add_remote_ctf_integration(monkeypatch, isolated_config):
     ctf_path = ctfs_path / "demo-ctfd"
     ctf = CTF(name="DemoCTFd", path=ctf_path, url=url)
 
-    # Clean slate
     if ctf_path.exists():
         shutil.rmtree(ctf_path)
     ctf_path.mkdir(parents=True, exist_ok=True)
 
-    # Pre-seed .env to bypass prompt
     (ctf_path / ".env").write_text(
         f"CTF_USERNAME={username}\nCTF_PASSWORD={password}\n", encoding="utf-8"
     )
 
     added = add_remote_ctf(ctf)
-    assert added, "Failed to add remote CTF"
+    assert added
 
     assert ctf_path.exists() and ctf_path.is_dir()
-    assert any(ctf_path.iterdir()), "Expected remote sync to create challenge data"
+    assert any(ctf_path.iterdir())
 
     original = {challenge.id for challenge in get_challenges()}
     assert sync_remote_ctf(ctf)
@@ -197,8 +188,6 @@ def test_add_remote_ctf_fails_when_client_unavailable(monkeypatch, isolated_conf
     ctfs_path = get_ctfs_path()
     ctf_path = ctfs_path / "failing-ctf"
     ctf = CTF(name="FailingCTF", path=ctf_path, url="https://example.invalid")
-
-    # Simulate inability to create a client/auth methods (network or URL failure)
 
     async def _no_client(url, platform=None):
         return None, None
@@ -217,8 +206,6 @@ def test_add_remote_ctf_fails_when_credentials_missing(monkeypatch, isolated_con
     ctf_path = ctfs_path / "nocreds"
     ctf = CTF(name="NoCreds", path=ctf_path, url="https://demo.ctfd.io/")
 
-    # Simulate available methods but user supplies no credentials
-
     async def _fake_methods(url, platform=None):
         return "dummy_client", ["creds"]
 
@@ -231,7 +218,6 @@ def test_add_remote_ctf_fails_when_credentials_missing(monkeypatch, isolated_con
 
 
 def test_a_pinned_platform_is_handed_to_ctfbridge(monkeypatch):
-    """Detection is asked for only when nothing was pinned."""
     import ctfbridge
 
     import pwnv.utils.remote as remote
@@ -252,7 +238,6 @@ def test_a_pinned_platform_is_handed_to_ctfbridge(monkeypatch):
 
 
 def test_the_platform_stored_on_a_ctf_is_used_for_every_later_call(monkeypatch):
-    """Pinning once is the point: it has to survive into the next command."""
     import pwnv.utils.remote as remote
 
     asked: list = []
@@ -275,7 +260,6 @@ def test_the_platform_stored_on_a_ctf_is_used_for_every_later_call(monkeypatch):
 
 
 def test_an_unknown_platform_is_rejected_with_the_ones_that_exist():
-    """A typo must not be sent to ctfbridge as if it were a platform."""
     from typer.testing import CliRunner
 
     from pwnv import app
@@ -291,7 +275,6 @@ def test_an_unknown_platform_is_rejected_with_the_ones_that_exist():
 
 
 def test_sync_pins_the_platform_on_the_ctf(monkeypatch):
-    """A CTF added before you knew what it was can be corrected in place."""
     from typer.testing import CliRunner
 
     import pwnv.utils as utils

--- a/tests/test_workflow_features.py
+++ b/tests/test_workflow_features.py
@@ -1,5 +1,3 @@
-"""Tests for the scaffold, pwncd, watch-sync, and status workflows."""
-
 import asyncio
 import json
 import textwrap
@@ -19,10 +17,6 @@ from pwnv.utils import (
     get_challenges,
     get_ctfs_path,
 )
-
-# --------------------------------------------------------------------------- #
-# fixtures
-# --------------------------------------------------------------------------- #
 
 
 def _ctf(name: str, *, running: Status = Status.running, url: str | None = None) -> CTF:
@@ -49,7 +43,6 @@ def _challenge(ctf: CTF, name: str, category: Category = Category.pwn, **kwargs)
 
 
 def _install_plugin(category: Category, name: str, marker: str) -> None:
-    """Write a plugin plus its template and select it for ``category``."""
     from pwnv.core.plugin_manager import plugin_manager
     from pwnv.utils.plugin import (
         get_plugins_directory,
@@ -86,21 +79,10 @@ def _install_plugin(category: Category, name: str, marker: str) -> None:
 
 
 def _runner() -> CliRunner:
-    """
-    A runner that keeps stderr out of stdout.
-
-    `pwncd` is `cd "$(pwnv challenge path)"`, so anything that leaks onto stdout
-    ends up in the path. Click 8.1 folds the two together unless asked not to.
-    """
     try:
         return CliRunner(mix_stderr=False)
     except TypeError:  # click >= 8.2 never mixes them
         return CliRunner()
-
-
-# --------------------------------------------------------------------------- #
-# scaffold
-# --------------------------------------------------------------------------- #
 
 
 def test_scaffold_writes_the_template_and_runs_plugin_logic():
@@ -118,7 +100,6 @@ def test_scaffold_writes_the_template_and_runs_plugin_logic():
 
 
 def test_scaffold_never_overwrites_work_in_progress():
-    """The whole point of the guard: two hours of exploit must survive."""
     ctf = _ctf("ScaffoldCTF")
     challenge = _challenge(ctf, "Baby ROP")
     _install_plugin(Category.pwn, "pwnplug", "PWN")
@@ -159,7 +140,6 @@ def test_scaffold_force_overwrites():
 
 
 def test_scaffold_applies_a_foreign_category_without_touching_the_challenge():
-    """A web challenge can get the pwn template; the record stays a web one."""
     ctf = _ctf("ScaffoldCTF")
     challenge = _challenge(ctf, "EZ XSS", category=Category.web)
     _install_plugin(Category.pwn, "pwnplug", "PWN")
@@ -184,7 +164,6 @@ def test_scaffold_applies_a_foreign_category_without_touching_the_challenge():
 
     assert result.exit_code == 0
     assert (challenge.path / "solve.py").read_text() == "# WEB EZ XSS\n"
-    # The suffix keeps both templates side by side instead of colliding.
     assert (challenge.path / "solve_pwn.py").read_text() == "# PWN EZ XSS\n"
 
     stored = next(ch for ch in get_challenges() if ch.name == "EZ XSS")
@@ -205,11 +184,6 @@ def test_scaffold_reports_a_category_with_no_plugin():
     assert "plugin select" in result.output
 
 
-# --------------------------------------------------------------------------- #
-# pwncd
-# --------------------------------------------------------------------------- #
-
-
 def test_challenge_path_prints_only_the_directory():
     ctf = _ctf("PathCTF")
     challenge = _challenge(ctf, "Baby ROP")
@@ -221,7 +195,6 @@ def test_challenge_path_prints_only_the_directory():
 
 
 def test_challenge_path_accepts_the_directory_name():
-    """`pwncd baby-rop` is what shell completion gives you."""
     ctf = _ctf("PathCTF")
     challenge = _challenge(ctf, "Baby ROP")
 
@@ -232,7 +205,6 @@ def test_challenge_path_accepts_the_directory_name():
 
 
 def test_duplicate_names_resolve_to_the_running_ctf():
-    """Every event has a "sanity"; the stopped one from last month is not it."""
     live = _ctf("LiveCTF")
     old = _ctf("OldCTF", running=Status.stopped)
     wanted = _challenge(live, "Sanity")
@@ -268,14 +240,12 @@ def test_ambiguous_names_across_running_ctfs_reach_the_picker(monkeypatch):
 
 
 def test_challenge_path_fails_loudly_on_a_miss():
-    """`pwncd typo` must not leave you in a random directory."""
     ctf = _ctf("PathCTF")
     _challenge(ctf, "Baby ROP")
 
     result = _runner().invoke(app, ["challenge", "path", "nope"])
 
     assert result.exit_code == 1
-    # Nothing on stdout, so `cd "$(...)"` has nothing to cd into.
     assert result.stdout.strip() == ""
     assert "does not exist" in result.stderr
 
@@ -293,11 +263,6 @@ def test_shell_init_rejects_an_unknown_shell():
     result = CliRunner().invoke(app, ["shell-init", "--shell", "nushell"])
 
     assert result.exit_code == 1
-
-
-# --------------------------------------------------------------------------- #
-# sync: attachments and diffs
-# --------------------------------------------------------------------------- #
 
 
 class _Attachment:
@@ -374,13 +339,12 @@ def test_unchanged_attachments_are_not_downloaded_twice():
         [_remote("Baby ROP", attachments=[_Attachment("chal.zip", b"binary")])],
     )
 
-    assert attachments.downloaded == ["Baby ROP"]  # not re-downloaded
+    assert attachments.downloaded == ["Baby ROP"]
     assert second["attachments_reused"] == ["Baby ROP"]
     assert second["unchanged"] == 1
 
 
 def test_a_republished_attachment_is_downloaded_again():
-    """Organisers ship fixed binaries mid-event; the digest has to notice."""
     ctf = _ctf("AttachCTF", url="https://x.invalid")
     client, attachments = _fake_client()
     _sync(
@@ -439,7 +403,6 @@ def test_sync_summarises_what_actually_changed():
         client,
         ctf,
         [
-            # Dynamic scoring dropped the price and someone solved it.
             _remote("Baby ROP", value=80, solved=True),
             _remote("Sanity", value=10),
             _remote("New Chal", value=500),
@@ -464,7 +427,6 @@ def test_sync_notices_an_edited_description():
 
 
 def test_watch_stops_when_the_ctf_stops(monkeypatch):
-    """A forgotten watcher must not poll a finished event all night."""
     import time
 
     import pwnv.utils as utils
@@ -515,11 +477,6 @@ def test_sync_renders_a_diff_instead_of_the_whole_scoreboard(monkeypatch):
     assert "12 unchanged" in result.output
 
 
-# --------------------------------------------------------------------------- #
-# status
-# --------------------------------------------------------------------------- #
-
-
 def test_status_detail_breaks_a_ctf_down_by_category():
     ctf = _ctf("StatusCTF", url="https://x.invalid")
     _challenge(
@@ -564,14 +521,7 @@ def test_status_json_carries_the_detail_and_current_scope():
     assert payload["current"]["ctf"] == "StatusCTF"
 
 
-# --------------------------------------------------------------------------- #
-# bundled examples
-# --------------------------------------------------------------------------- #
-
-
 def _run_init(isolated_config, tmp_path, monkeypatch, *extra: str):
-    """Run `pwnv init` for real, minus uv."""
-    # init refuses to run over an existing config, and the fixture writes one.
     isolated_config.unlink()
     monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/uv")
     monkeypatch.setattr(
@@ -594,7 +544,6 @@ def _run_init(isolated_config, tmp_path, monkeypatch, *extra: str):
 def test_init_copies_the_bundled_plugins_and_templates(
     isolated_config, tmp_path, monkeypatch
 ):
-    """A fresh workspace should be able to scaffold a pwn challenge right away."""
     from pwnv.utils import (
         get_plugin_selection,
         get_plugins_directory,
@@ -620,7 +569,6 @@ def test_init_can_skip_the_bundled_examples(isolated_config, tmp_path, monkeypat
 
 
 def test_bundled_examples_never_overwrite_your_edits():
-    """Re-running the install must not undo a plugin you customised."""
     from pwnv.utils import (
         get_plugin_selection,
         get_plugins_directory,
@@ -641,7 +589,6 @@ def test_bundled_examples_never_overwrite_your_edits():
 
 
 def test_the_bundled_plugin_actually_loads():
-    """The example is the first thing anyone reads, so it has to import."""
     from pwnv.core.plugin_manager import plugin_manager
     from pwnv.utils import install_bundled_examples
 

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -97,7 +97,6 @@ def test_export_removes_flags_and_submission_history(tmp_path):
 
 
 def _fresh_machine(tmp_path, name: str = "new-machine"):
-    """Point the workspace at an empty CTF root, as a new install would be."""
     ctfs_path = tmp_path / name
     ctfs_path.mkdir(parents=True, exist_ok=True)
     save_config(
@@ -112,7 +111,6 @@ def _fresh_machine(tmp_path, name: str = "new-machine"):
 
 
 def test_restore_puts_the_files_back_under_the_new_ctf_root(tmp_path):
-    """The move-to-a-new-PC path: backup here, restore against another root."""
     _, challenge = _create_workspace(tmp_path)
     (challenge.path / "solve.py").write_text("print('pwn')", encoding="utf-8")
     backup = backup_workspace(tmp_path / "backup")
@@ -131,12 +129,10 @@ def test_restore_puts_the_files_back_under_the_new_ctf_root(tmp_path):
 
 
 def test_restore_keeps_the_directory_names_the_backup_used(tmp_path):
-    """Names are recomputed on import; a backup has real directories to keep."""
     ctf = CTF(name="Example CTF", path=get_ctfs_path() / "example-ctf")
     challenge = Challenge(
         name="Web Challenge",
         ctf_id=ctf.id,
-        # `_unique_challenge_path` produces suffixes like this on a name clash.
         path=ctf.path / "web" / "web-challenge_2",
         category=Category.web,
     )


### PR DESCRIPTION
## What

- The landing page used `:material-...:` icons without the `pymdownx.emoji` extension, so readthedocs printed them literally. The extension is now configured and the icons render as inline SVGs.
- PWNV_DEBUG never shipped as a real feature; every mention of it (code, docs, tests) is gone.
- A style pass trims the AI-era comment sprawl back to the project's original voice: one-line docstrings, comments near zero, nothing clever. No behavior changes; the generated CLI reference is regenerated to match.

## Checks

- 140 tests pass, plus the end-to-end smoke script
- ruff clean, `mkdocs build --strict` and `gen_cli_docs.py --check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)