### PR TITLE
fix: publish the python classifiers the pyversions badge reads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,11 @@ authors = [
   {name = "Shayan Alinejad", email = "shayan.alinejad@proton.me"}
 ]
 keywords = ["ctf", "pwn", "rev", "management", "cli", "ctfd", "rctf", "tool", "workspace", "automation", "workflow", "challenges"]
+classifiers = [
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+]
 requires-python = ">=3.12"
 dependencies = [
     # Imported directly, to resolve the config directory without typer.


### PR DESCRIPTION
Shields' `pypi/pyversions` badge reads the trove classifiers from the latest PyPI release, not `requires-python`; pwnv 0.5.0 shipped with none, so the README badge renders "python missing". This adds the 3.12–3.14 classifiers (verified in a locally built wheel, `twine check` passes).

This commit was originally pushed to #20 but arrived after the merge, so it re-lands here. It should go in before the v0.6.0 release so the badge resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)