### PR TITLE
docs: align the quickstart workspace table

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -90,12 +90,12 @@ pwnv status --detail
 ```
 
 ```
-                       pwnv workspace
-┏━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━┳━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━┓
-┃ CTF     ┃ Status  ┃ Kind   ┃ Solved ┃ Points ┃ Categories ┃
-┡━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━╇━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━┩
-│ DemoCTF │ running │ remote │   4/23 │    950 │ pwn, web   │
-└─────────┴─────────┴────────┴────────┴────────┴────────────┘
+                        pwnv workspace
+┌─────────┬─────────┬────────┬────────┬──────────┬────────────┐
+│ CTF     │ Status  │ Kind   │ Solved │   Points │ Categories │
+├─────────┼─────────┼────────┼────────┼──────────┼────────────┤
+│ DemoCTF │ running │ remote │   4/23 │ 950/3200 │ pwn, web   │
+└─────────┴─────────┴────────┴────────┴──────────┴────────────┘
 ```
 
 `--detail` adds per-category progress, recent solves, and what is left. Add


### PR DESCRIPTION
The status sample used Rich's HEAVY_HEAD box, mixing heavy header glyphs with a light body. Read the Docs falls back to another font for the heavy glyphs, so the header drifted out of alignment with the body. Redraw it in a single-weight light box and show Points as the earned/total fraction the command actually prints.

## What this changes

<!-- One or two sentences. Link the issue if there is one: Fixes #123. -->

## Why

<!-- What was wrong or missing. Skip if the change is obvious from the title. -->

## Checklist

- [ ] `uv run pytest` passes
- [ ] `uv run ruff check . && uv run ruff format --check .` is clean
- [ ] `uv run mypy pwnv` is clean
- [ ] Docs updated, if the change is user-visible
- [ ] `uv run python scripts/gen_cli_docs.py` re-run, if a command or option changed
