### PR TITLE
docs: render the quickstart status table as a Markdown table

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -89,14 +89,9 @@ non-zero — so a script cannot mistake a wrong flag for a solve.
 pwnv status --detail
 ```
 
-```
-                        pwnv workspace
-┌─────────┬─────────┬────────┬────────┬──────────┬────────────┐
-│ CTF     │ Status  │ Kind   │ Solved │   Points │ Categories │
-├─────────┼─────────┼────────┼────────┼──────────┼────────────┤
-│ DemoCTF │ running │ remote │   4/23 │ 950/3200 │ pwn, web   │
-└─────────┴─────────┴────────┴────────┴──────────┴────────────┘
-```
+| CTF     | Status  | Kind   | Solved | Points   | Categories |
+| ------- | ------- | ------ | -----: | -------: | ---------- |
+| DemoCTF | running | remote |   4/23 | 950/3200 | pwn, web   |
 
 `--detail` adds per-category progress, recent solves, and what is left. Add
 `--json` to get the same numbers as data.


### PR DESCRIPTION
Material's code font (SFMono/Consolas/Menlo/Roboto Mono) has no box-drawing glyphs, so the browser substituted them from another font at a different advance width and the box-art columns drifted on the site regardless of heavy or light box style. Use a real Markdown table so it renders as an HTML table that cannot misalign under any font.

## What this changes

<!-- One or two sentences. Link the issue if there is one: Fixes #123. -->

## Why

<!-- What was wrong or missing. Skip if the change is obvious from the title. -->

## Checklist

- [ ] `uv run pytest` passes
- [ ] `uv run ruff check . && uv run ruff format --check .` is clean
- [ ] `uv run mypy pwnv` is clean
- [ ] Docs updated, if the change is user-visible
- [ ] `uv run python scripts/gen_cli_docs.py` re-run, if a command or option changed
